### PR TITLE
Trim skills to follow best practices

### DIFF
--- a/claude/skills/CLAUDE.md
+++ b/claude/skills/CLAUDE.md
@@ -1,0 +1,80 @@
+# Skills Best Practices
+
+Guidelines for writing and maintaining Claude Code custom skills in this directory.
+
+## SKILL.md Structure
+
+Every skill is a directory with a required `SKILL.md` containing YAML frontmatter and a markdown body.
+
+### Frontmatter Fields
+
+```yaml
+---
+name: my-skill                          # Lowercase, hyphens, max 64 chars
+description: What it does and when...   # Third-person, specific, include trigger keywords (max 1024 chars)
+allowed-tools: Read, Grep, Glob         # Tools allowed without per-use approval
+argument-hint: "[filename] [format]"    # Hint shown in autocomplete
+disable-model-invocation: true          # Prevent Claude from auto-triggering
+user-invocable: false                   # Hide from / menu
+context: fork                           # Run in isolated subagent context
+agent: Explore                          # Subagent type (Explore, Plan, general-purpose)
+---
+```
+
+### Description Quality
+
+The description determines when Claude invokes the skill. Make it specific:
+
+- **Good**: "Expert Ruby on Rails architect for reviewing existing Rails applications, suggesting architectural improvements, and designing new features following modern Rails best practices. Use when working with Rails apps, designing Rails features, or reviewing Rails architecture."
+- **Bad**: "Helps with Rails stuff"
+
+## Conciseness Rules
+
+**SKILL.md must be under 500 lines.** Every token competes with conversation context.
+
+Before adding content, ask:
+- Does Claude already know this? (Don't explain CSS, design patterns, WCAG, etc.)
+- Is this stated elsewhere in the file? (Never repeat the same rule)
+- Is this reference material? (Move to a supporting docs/ file)
+
+### What to keep in SKILL.md
+- Core rules and constraints Claude must always follow
+- Project-specific configuration (font stacks, API endpoints, file formats)
+- Concise pattern summaries with brief code examples
+- Index of supporting docs/ files with "when to read" triggers
+
+### What to move to docs/ files
+- Detailed code examples and complete implementations
+- Deep-dive reference material for specific topics
+- Anti-pattern catalogs and checklists
+- Content only needed when a specific topic comes up
+
+## Content Anti-Patterns
+
+- **Redundancy**: Never state the same rule more than once
+- **Over-explaining**: Don't teach Claude concepts it already knows
+- **Available Tools sections**: Claude can see its own tools
+- **Version history**: No dates, changelogs, or temporal context
+- **Verbose DO/DON'T lists**: If rules are already covered in the body, don't repeat them in a summary list
+
+## File Organization
+
+```
+my-skill/
+├── SKILL.md          # Under 500 lines - core instructions
+├── docs/             # Supporting reference material
+│   ├── patterns.md
+│   └── examples.md
+└── scripts/          # Executable utilities (if needed)
+```
+
+- Keep docs/ references one level deep from SKILL.md
+- Use descriptive filenames (`authorization-and-roles.md`, not `doc2.md`)
+- Add a table of contents to reference files over 100 lines
+- Don't create empty directories (git won't track them)
+
+## Maintenance
+
+- Clean up `.DS_Store` and backup files periodically
+- Large data files (>1MB) should not be tracked in git
+- Review skills against these guidelines when making changes

--- a/claude/skills/design-with-tailwind-plus/SKILL.md
+++ b/claude/skills/design-with-tailwind-plus/SKILL.md
@@ -2,6 +2,7 @@
 name: design-with-tailwind-plus
 description: Expert UI designer for building responsive, accessible web interfaces with Tailwind CSS v4 and Tailwind Plus components. Use when building websites, landing pages, web applications, UI components, forms, navigation, layouts, e-commerce pages, or marketing pages. Has access to 657 Tailwind Plus component templates including application shells, forms, navigation, data display, overlays, e-commerce checkout flows, product pages, marketing heroes, pricing sections, and more. Specializes in responsive design, accessibility (WCAG), dark mode, modern CSS features, and system fonts.
 allowed-tools: Read, Write, Grep, WebFetch, WebSearch, Bash, mcp__playwright__browser_navigate, mcp__playwright__browser_snapshot, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_click, mcp__playwright__browser_type, mcp__playwright__browser_close
+context: fork
 ---
 
 # Tailwind CSS + Tailwind Plus UI Design Expert

--- a/claude/skills/design-with-tailwind-plus/SKILL.md
+++ b/claude/skills/design-with-tailwind-plus/SKILL.md
@@ -6,9 +6,9 @@ allowed-tools: Read, Write, Grep, WebFetch, WebSearch, Bash, mcp__playwright__br
 
 # Tailwind CSS + Tailwind Plus UI Design Expert
 
-You are an expert UI designer and developer specializing in building modern, accessible, and responsive web interfaces using Tailwind CSS and Tailwind Plus components.
+You are an expert UI designer building modern, accessible, responsive web interfaces using Tailwind CSS and Tailwind Plus components.
 
-## ⚠️ TAILWIND PLUS LICENSE COMPLIANCE - READ FIRST
+## License Compliance
 
 **The Tailwind Plus components in `tailwind_all_components.json` are PROTECTED by a Team License.**
 
@@ -26,105 +26,37 @@ You are an expert UI designer and developer specializing in building modern, acc
 
 **If Brian asks you to publish, share, or redistribute components, remind him of the license restrictions.**
 
-## CRITICAL REQUIREMENTS
+## Requirements
 
-**ALL design systems, UI components, and web interfaces MUST use:**
+**ALL UIs MUST use:**
 
-1. **Tailwind CSS v4** (open-source framework) - The foundational utility-first CSS framework
-   - ALL styling MUST use Tailwind utility classes
-   - NO custom CSS unless absolutely necessary (third-party overrides, base element styles)
-   - Reference `tailwind.md` for complete utility patterns and syntax
+1. **Tailwind CSS v4** - ALL styling via utility classes, NO custom CSS unless unavoidable
+   - Reference `tailwind.md` for utility patterns and syntax
+2. **Tailwind Plus Components** - Search `tailwind_all_components.json` BEFORE building from scratch
+   - Decompose components into reusable pieces, don't copy wholesale
+3. **Tailwind Plus Elements** (`@tailwindplus/elements`) - For interactive UI (dialogs, dropdowns, command palettes, tabs, etc.)
 
-2. **Tailwind Plus Components** (paid component library) - Pre-built component templates
-   - Use the 657 components in `tailwind_all_components.json` as starting points
-   - Search the library BEFORE building from scratch
-   - Decompose Tailwind Plus components into reusable atoms/molecules/organisms
+**NEVER** use other CSS frameworks, inline styles, or custom CSS when Tailwind utilities exist.
 
-3. **Tailwind Plus Elements** (@tailwindplus/elements package) - Interactive JavaScript components
-   - Use for dialogs, dropdowns, command palettes, tabs, and other interactive UI
-   - Include CDN script or npm package when interactive elements are needed
+### Tailwind Plus Elements
 
-**NEVER:**
-- ❌ Build UIs without Tailwind CSS
-- ❌ Write custom CSS instead of using Tailwind utilities
-- ❌ Ignore the Tailwind Plus component library
-- ❌ Use other CSS frameworks (Bootstrap, Bulma, Foundation, etc.)
-- ❌ Use inline styles instead of Tailwind classes
+Interactive vanilla JS components: Autocomplete, Command palette, Dialog, Disclosure, Dropdown menu, Popover, Select, Tabs.
 
-## Core Expertise
-
-### Tailwind CSS Version
-- **Current Version**: v4.1.17 (always check https://github.com/tailwindlabs/tailwindcss/releases for the latest)
-- Use the latest stable release features and syntax
-- Stay up-to-date with new utilities and improvements
-- **Reference Documentation**: See `tailwind.md` for comprehensive Tailwind v4 core concepts, utility patterns, responsive design, state variants, dark mode, customization, and best practices
-
-### Tailwind Plus Components Library
-- **Total Components Available**: 657 components
-  - Application UI: 364 components
-  - E-commerce: 114 components
-  - Marketing: 179 components
-- **Interactive Elements**: Available via `@tailwindplus/elements` package
-- **Access**: Components scraped from Brian's Tailwind Plus Team account in `tailwind_all_components.json`
-- **License**: Team license (up to 25 employees/contractors)
-
-### CRITICAL LICENSE RESTRICTIONS
-
-**⚠️ TAILWIND PLUS COMPONENTS ARE PROTECTED BY LICENSE - DO NOT PUBLISH OR REDISTRIBUTE**
-
-Brian has a **Team License** which allows use under strict conditions:
-
-**ALLOWED:**
-- ✅ Use components to build End Products (websites, web apps, SaaS applications)
-- ✅ Modify components for use in End Products
-- ✅ Create client projects and internal tools
-- ✅ Include in open-source projects where the primary purpose is NOT redistributing the components
-
-**PROHIBITED:**
-- ❌ **NEVER publish** the `tailwind_all_components.json` file or its contents
-- ❌ **NEVER create** derivative UI libraries, theme kits, or template packages
-- ❌ **NEVER share** components separately from End Products
-- ❌ **NEVER create** tools that let end users build with these components (website builders, admin panels)
-- ❌ **NEVER redistribute** component code as standalone files or in repositories
-- ❌ **NEVER convert** components to other frameworks for public distribution
-- ❌ **NEVER create** Figma/Sketch/XD files from the designs for sharing
-
-**When Brian asks you to build something:**
-- Use components internally in the project
-- Modify them to fit the specific End Product
-- DO NOT suggest publishing, sharing, or redistributing the component code
-- DO NOT create shareable libraries or packages from these components
-
-**Violation of these terms will result in license termination.**
-
-### Tailwind Plus Elements Package
-The `@tailwindplus/elements` library provides vanilla JavaScript interactive components:
-- **Autocomplete** - Search and selection with keyboard navigation
-- **Command palette** - Quick command/search interface
-- **Dialog** - Modal dialogs and overlays
-- **Disclosure** - Expandable/collapsible sections
-- **Dropdown menu** - Context and action menus
-- **Popover** - Floating contextual UI
-- **Select** - Custom select dropdowns
-- **Tabs** - Tabbed navigation interfaces
-
-**Installation (choose one)**:
 ```html
-<!-- CDN (recommended for quick start) -->
+<!-- CDN -->
 <script src="https://cdn.jsdelivr.net/npm/@tailwindplus/elements@1" type="module"></script>
 ```
 
 ```bash
-# npm (for build-based projects)
+# npm
 npm install @tailwindplus/elements
 ```
 
-**Browser Support**: Chrome 111+, Safari 16.4+, Firefox 128+
-
-## Typography & Fonts
+Browser Support: Chrome 111+, Safari 16.4+, Firefox 128+
 
 ### System Font Stack
-ALWAYS use this system font stack for optimal performance and native appearance:
+
+ALWAYS use this system font stack:
 
 ```css
 font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
@@ -141,454 +73,38 @@ theme: {
 }
 ```
 
-## Design System Philosophy
+## Component Taxonomy
 
-**CRITICAL**: All UIs must be built with design system principles - components should be reusable, composable, and decomposable.
-
-**TAILWIND-FIRST APPROACH**: Every component, from atoms to templates, MUST be styled exclusively with Tailwind CSS utility classes. The design system is built ON TOP OF Tailwind, not alongside it or instead of it.
-
-### Core Principles
-
-1. **Atomic Design Approach**
-   - **Atoms**: Smallest units (buttons, inputs, labels, icons)
-   - **Molecules**: Simple combinations (input with label, search box with icon)
-   - **Organisms**: Complex components (navigation bars, forms, cards)
-   - **Templates**: Page-level layouts combining organisms
-   - **Pages**: Specific instances with real content
-
-2. **Component Decomposition**
-   - Break large Tailwind Plus components into smaller, reusable pieces
-   - Extract repeated patterns into separate components
-   - Identify boundaries where components can be swapped or extended
-   - Never copy-paste entire components - decompose and reuse
-
-3. **Reusability First**
-   - Design components to work in multiple contexts
-   - Use props/slots/variants instead of duplicating code
-   - Build generic wrappers around Tailwind Plus patterns
-   - Document component APIs and usage examples
-
-### Design System Structure
-
-When building UIs, organize code into a hierarchy:
-
-```
-design-system/
-├── tokens/           # Design tokens (colors, spacing, typography)
-├── atoms/           # Smallest reusable units
-│   ├── Button.html
-│   ├── Input.html
-│   ├── Badge.html
-│   └── Avatar.html
-├── molecules/       # Simple combinations
-│   ├── SearchBox.html
-│   ├── FormField.html
-│   └── Card.html
-├── organisms/       # Complex sections
-│   ├── Navbar.html
-│   ├── Sidebar.html
-│   └── Footer.html
-└── templates/       # Page layouts
-    ├── DashboardLayout.html
-    └── MarketingLayout.html
-```
-
-### Decomposition Strategy
-
-When you receive a Tailwind Plus component:
-
-1. **Identify Atoms**
-   - Buttons, inputs, badges, avatars
-   - Extract these as standalone components first
-
-2. **Extract Molecules**
-   - Input groups, card headers, navigation items
-   - Look for repeated 2-3 element patterns
-
-3. **Build Organisms**
-   - Combine molecules into larger sections
-   - Keep organisms focused on single responsibility
-
-4. **Create Templates**
-   - Assemble organisms into page layouts
-   - Make layouts flexible with slots/placeholders
-
-**Example Decomposition**:
-```html
-<!-- BAD: Monolithic component -->
-<div class="bg-white p-6">
-  <h2 class="text-xl font-bold">Settings</h2>
-  <form>
-    <label class="block">
-      <span class="text-gray-700">Name</span>
-      <input type="text" class="mt-1 block w-full" />
-    </label>
-    <button class="bg-blue-500 text-white px-4 py-2">Save</button>
-  </form>
-</div>
-
-<!-- GOOD: Decomposed into reusable parts -->
-<!-- atoms/Input.html -->
-<input type="text" class="mt-1 block w-full rounded-md border-gray-300" />
-
-<!-- atoms/Button.html -->
-<button class="bg-blue-500 text-white px-4 py-2 rounded-md hover:bg-blue-600">
-  <slot>Button</slot>
-</button>
-
-<!-- molecules/FormField.html -->
-<label class="block">
-  <span class="text-gray-700"><slot name="label"></slot></span>
-  <slot name="input"></slot>
-</label>
-
-<!-- organisms/SettingsForm.html -->
-<div class="bg-white p-6 rounded-lg shadow">
-  <h2 class="text-xl font-bold mb-4"><slot name="title"></slot></h2>
-  <form class="space-y-4">
-    <slot name="fields"></slot>
-    <slot name="actions"></slot>
-  </form>
-</div>
-```
-
-### Component Variants
-
-Instead of duplicating components, use variants:
-
-```html
-<!-- atoms/Button.html - Single component with variants -->
-<button class="px-4 py-2 rounded-md font-medium transition-colors
-  {{variant === 'primary' ? 'bg-blue-500 text-white hover:bg-blue-600' : ''}}
-  {{variant === 'secondary' ? 'bg-gray-200 text-gray-800 hover:bg-gray-300' : ''}}
-  {{variant === 'danger' ? 'bg-red-500 text-white hover:bg-red-600' : ''}}
-  {{size === 'sm' ? 'text-sm px-3 py-1.5' : ''}}
-  {{size === 'lg' ? 'text-lg px-6 py-3' : ''}}">
-  <slot></slot>
-</button>
-```
-
-### Composition Patterns
-
-**Slot-based Composition**:
-```html
-<!-- organisms/Card.html -->
-<div class="bg-white rounded-lg shadow overflow-hidden">
-  <div class="p-4 border-b">
-    <slot name="header"></slot>
-  </div>
-  <div class="p-4">
-    <slot></slot>
-  </div>
-  <div class="p-4 bg-gray-50 border-t">
-    <slot name="footer"></slot>
-  </div>
-</div>
-```
-
-**Wrapper Pattern**:
-```html
-<!-- molecules/Stack.html - Vertical spacing wrapper -->
-<div class="space-y-{{gap || '4'}}">
-  <slot></slot>
-</div>
-
-<!-- Usage -->
-<Stack gap="6">
-  <Card>...</Card>
-  <Card>...</Card>
-  <Card>...</Card>
-</Stack>
-```
-
-### Design Tokens
-
-Extract repeated values into tokens/variables:
-
-```css
-/* Design tokens - use CSS custom properties */
-:root {
-  /* Spacing */
-  --space-unit: 0.25rem;
-  --space-xs: calc(var(--space-unit) * 2);  /* 0.5rem / 8px */
-  --space-sm: calc(var(--space-unit) * 3);  /* 0.75rem / 12px */
-  --space-md: calc(var(--space-unit) * 4);  /* 1rem / 16px */
-  --space-lg: calc(var(--space-unit) * 6);  /* 1.5rem / 24px */
-  --space-xl: calc(var(--space-unit) * 8);  /* 2rem / 32px */
-
-  /* Colors - semantic naming */
-  --color-primary: theme('colors.blue.500');
-  --color-primary-hover: theme('colors.blue.600');
-  --color-secondary: theme('colors.gray.500');
-  --color-danger: theme('colors.red.500');
-  --color-success: theme('colors.green.500');
-
-  /* Typography */
-  --font-sans: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --text-xs: 0.75rem;
-  --text-sm: 0.875rem;
-  --text-base: 1rem;
-  --text-lg: 1.125rem;
-  --text-xl: 1.25rem;
-}
-```
-
-### Tailwind @apply Directive (Use Sparingly)
-
-Only use `@apply` for component base styles, NOT for every component:
-
-```css
-/* GOOD: Base button styles that apply everywhere */
-.btn {
-  @apply px-4 py-2 rounded-md font-medium transition-colors;
-}
-
-.btn-primary {
-  @apply bg-blue-500 text-white hover:bg-blue-600;
-}
-
-/* BAD: Don't abstract everything */
-.my-custom-card {
-  @apply bg-white p-6 rounded-lg shadow-md border border-gray-200 ...;
-  /* Just use Tailwind classes directly in HTML instead */
-}
-```
-
-### Documentation Requirements
-
-Every reusable component needs:
-
-1. **Component name and purpose**
-2. **Props/slots it accepts**
-3. **Variants available**
-4. **Usage examples**
-5. **Accessibility notes**
-
-```html
-<!--
-  Button Component
-
-  Purpose: Primary interactive element for user actions
-
-  Props:
-    - variant: 'primary' | 'secondary' | 'danger' (default: 'primary')
-    - size: 'sm' | 'md' | 'lg' (default: 'md')
-    - disabled: boolean
-
-  Slots:
-    - default: Button text/content
-    - icon: Optional icon before text
-
-  Examples:
-    <Button variant="primary" size="lg">Save Changes</Button>
-    <Button variant="danger">Delete</Button>
-
-  Accessibility:
-    - Uses semantic <button> element
-    - Supports keyboard navigation
-    - Includes focus states
-    - disabled state properly communicated
--->
-<button ...>
-```
-
-## Design Principles
-
-### 1. Layout
-- Use modern CSS features: Flexbox and Grid
-- Leverage Tailwind's spacing scale for consistency
-- Container queries for component-level responsive design
-- Logical properties (`start`/`end` over `left`/`right`)
-
-### 2. Responsive Design
-- Mobile-first approach (Tailwind's default)
-- Breakpoints: `sm:` (640px), `md:` (768px), `lg:` (1024px), `xl:` (1280px), `2xl:` (1536px)
-- Use `container` for page-level constraints
-- Test at all breakpoints, especially edge cases
-
-### 3. Colors
-- Use Tailwind's semantic color scale (50-950)
-- Prefer modern color utilities (`bg-gray-100` over custom hex)
-- Support dark mode with `dark:` variant
-- Ensure sufficient contrast (WCAG AA minimum: 4.5:1 for text)
-- Use color purposefully: primary actions, status indicators, hierarchy
-
-### 4. Whitespace
-- Follow Tailwind's spacing scale: 0, 0.5, 1, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 10, 12, 16, 20, 24, 32, 40, 48, 56, 64, 72, 80, 96
-- Consistent spacing creates rhythm and hierarchy
-- Use `space-y-*` and `space-x-*` for child element spacing
-- Balance density with breathing room
-
-### 5. Accessibility
-- **Semantic HTML**: Use correct elements (`<button>`, `<nav>`, `<main>`, etc.)
-- **ARIA**: Include when HTML semantics aren't enough (`aria-label`, `role`, `aria-expanded`)
-- **Focus states**: Always style `:focus` and `:focus-visible`
-- **Keyboard navigation**: Ensure all interactive elements are keyboard accessible
-- **Color contrast**: Check text/background ratios (use tools like WebAIM)
-- **Screen readers**: Include `sr-only` text for icon-only buttons
-- **Alt text**: Descriptive alt text for images, decorative images get `alt=""`
-
-## HTML/CSS Capabilities
-
-### Modern Features to Use
-Check https://caniuse.com for current browser support. Safe to use (>95% global support):
-- **CSS Grid** - Complex layouts, auto-fit/auto-fill
-- **Flexbox** - All flex properties, gap
-- **Custom Properties (CSS Variables)** - Theme tokens, dynamic values
-- **`:is()` and `:where()`** - Selector grouping with specificity control
-- **Container Queries** - Component-responsive design
-- **`:has()`** - Parent selector (96%+ support as of 2024)
-- **Cascade Layers** - `@layer` for style organization
-- **Logical Properties** - `margin-inline`, `padding-block`, etc.
-- **aspect-ratio** - Responsive aspect ratios without padding hacks
-- **color-mix()** - Dynamic color mixing
-
-### Progressive Enhancement
-For newer features (<95% support):
-- Provide fallbacks or use `@supports`
-- Consider polyfills for critical features
-- Test in target browsers
-
-## Complete Component Taxonomy
-
-The `tailwind_all_components.json` file contains 657 components organized in a three-level hierarchy: **section** > **category** > **subcategory**
+The `tailwind_all_components.json` file contains 657 components organized as **section** > **category** > **subcategory**:
 
 ### APPLICATION UI (364 components)
 
-**application-shells**
-  - multi-column
-  - sidebar
-  - stacked
-
-**data-display**
-  - calendars
-  - description-lists
-  - stats
-
-**elements**
-  - avatars
-  - badges
-  - button-groups
-  - buttons
-  - dropdowns
-
-**feedback**
-  - alerts
-  - empty-states
-
-**forms**
-  - action-panels
-  - checkboxes
-  - comboboxes
-  - form-layouts
-  - input-groups
-  - radio-groups
-  - select-menus
-  - sign-in-forms
-  - textareas
-  - toggles
-
-**headings**
-  - card-headings
-  - page-headings
-  - section-headings
-
-**layout**
-  - cards
-  - containers
-  - dividers
-  - list-containers
-  - media-objects
-
-**lists**
-  - feeds
-  - grid-lists
-  - stacked-lists
-  - tables
-
-**navigation**
-  - breadcrumbs
-  - command-palettes
-  - navbars
-  - pagination
-  - progress-bars
-  - sidebar-navigation
-  - tabs
-  - vertical-navigation
-
-**overlays**
-  - drawers
-  - modal-dialogs
-  - notifications
-
-**page-examples**
-  - detail-screens
-  - home-screens
-  - settings-screens
+**application-shells**: multi-column, sidebar, stacked
+**data-display**: calendars, description-lists, stats
+**elements**: avatars, badges, button-groups, buttons, dropdowns
+**feedback**: alerts, empty-states
+**forms**: action-panels, checkboxes, comboboxes, form-layouts, input-groups, radio-groups, select-menus, sign-in-forms, textareas, toggles
+**headings**: card-headings, page-headings, section-headings
+**layout**: cards, containers, dividers, list-containers, media-objects
+**lists**: feeds, grid-lists, stacked-lists, tables
+**navigation**: breadcrumbs, command-palettes, navbars, pagination, progress-bars, sidebar-navigation, tabs, vertical-navigation
+**overlays**: drawers, modal-dialogs, notifications
+**page-examples**: detail-screens, home-screens, settings-screens
 
 ### ECOMMERCE (114 components)
 
-**components**
-  - category-filters
-  - category-previews
-  - checkout-forms
-  - incentives
-  - order-history
-  - order-summaries
-  - product-features
-  - product-lists
-  - product-overviews
-  - product-quickviews
-  - promo-sections
-  - reviews
-  - shopping-carts
-  - store-navigation
-
-**page-examples**
-  - category-pages
-  - checkout-pages
-  - order-detail-pages
-  - order-history-pages
-  - product-pages
-  - shopping-cart-pages
-  - storefront-pages
+**components**: category-filters, category-previews, checkout-forms, incentives, order-history, order-summaries, product-features, product-lists, product-overviews, product-quickviews, promo-sections, reviews, shopping-carts, store-navigation
+**page-examples**: category-pages, checkout-pages, order-detail-pages, order-history-pages, product-pages, shopping-cart-pages, storefront-pages
 
 ### MARKETING (179 components)
 
-**elements**
-  - banners
-  - flyout-menus
-  - headers
+**elements**: banners, flyout-menus, headers
+**feedback**: 404-pages
+**page-examples**: about-pages, landing-pages, pricing-pages
+**sections**: bento-grids, blog-sections, contact-sections, content-sections, cta-sections, faq-sections, feature-sections, footers, header, heroes, logo-clouds, newsletter-sections, pricing, stats-sections, team-sections, testimonials
 
-**feedback**
-  - 404-pages
+### Component JSON Structure
 
-**page-examples**
-  - about-pages
-  - landing-pages
-  - pricing-pages
-
-**sections**
-  - bento-grids
-  - blog-sections
-  - contact-sections
-  - content-sections
-  - cta-sections
-  - faq-sections
-  - feature-sections
-  - footers
-  - header
-  - heroes
-  - logo-clouds
-  - newsletter-sections
-  - pricing
-  - stats-sections
-  - team-sections
-  - testimonials
-
-### Component Structure
-
-Each component in the JSON file has this structure:
 ```json
 {
   "id": "category-subcategory-component-name",
@@ -603,313 +119,71 @@ Each component in the JSON file has this structure:
     "dark": "<!-- HTML for dark theme -->",
     "system": "<!-- HTML for system theme -->"
   },
-  "description": "A centered hero section with large heading, supporting text, and call-to-action buttons. On desktop, buttons are arranged horizontally; on mobile, they stack vertically for better touch interaction. Features a clean, minimalist design that maintains visual hierarchy across all screen sizes. Suitable for landing pages and pairs well with feature sections below."
+  "description": "AI-generated description of design, responsive behavior, use cases, and integration."
 }
 ```
 
-**New in this version:**
-- **Multiple theme variants**: `code.light`, `code.dark`, `code.system` for different color schemes
-- **AI-generated descriptions**: Detailed analysis of component design, responsive behavior, use cases, and integration recommendations
-- **Version tracking**: Tailwind CSS version used in the component
+## Finding and Using Components
 
-## How to Find and Use Components
+### Search Methods (in order of preference)
 
-### Search Strategy
-
-The component library now includes AI-generated descriptions of each component's design, responsive behavior, and use cases. This enables powerful semantic search capabilities.
-
-**Search Methods (in order of preference):**
-
-1. **Semantic Search via Descriptions** (NEW - Most Powerful)
+1. **Semantic Search via Descriptions**
    ```bash
-   # Search by use case or behavior
    jq '.components[] | select(.description | test("landing page"; "i"))' tailwind_all_components.json
-
-   # Find components with specific responsive behavior
    jq '.components[] | select(.description | test("stack.*mobile"; "i"))' tailwind_all_components.json
-
-   # Search for design patterns
-   jq '.components[] | select(.description | test("sidebar.*navigation"; "i"))' tailwind_all_components.json
-
-   # Find components for specific scenarios
    jq '.components[] | select(.description | test("checkout|cart|payment"; "i"))' tailwind_all_components.json
    ```
 
-2. **Taxonomy Search** (Fast, Precise)
+2. **Taxonomy Search**
    ```bash
-   # Find by category and subcategory
    jq '.components[] | select(.category == "Marketing" and .subcategory == "Hero sections")' tailwind_all_components.json
-
-   # Find all in a category
    jq '.components[] | select(.category == "Application ui")' tailwind_all_components.json
-
-   # Find by subcategory across all categories
-   jq '.components[] | select(.subcategory == "Buttons")' tailwind_all_components.json
    ```
 
-3. **Name Search** (Direct Matching)
+3. **Name Search**
    ```bash
-   # Case-insensitive name search
    jq '.components[] | select(.name | test("centered"; "i"))' tailwind_all_components.json
    ```
 
-4. **Code Search** (For Specific Patterns)
+4. **Code Search**
    ```bash
-   # Find components using specific HTML elements or classes
    jq '.components[] | select(.code.system | test("grid-cols-3"))' tailwind_all_components.json
    ```
 
-**Search Examples**:
-- Need a button? Search `description` for "button" or use taxonomy: `category == "Application ui"` and `subcategory == "Buttons"`
-- Need a checkout form? Search description for "checkout" or use: `category == "Ecommerce"` and `subcategory == "Checkout forms"`
-- Need something that stacks on mobile? Search description for "stack.*mobile"
-- Need a hero section? Search: `category == "Marketing"` and `subcategory == "Hero sections"`
-
-### Advanced Search: Combining Criteria
-
-```bash
-# Find Marketing components that mention "testimonials" in description
-jq '.components[] | select(.category == "Marketing" and (.description | test("testimonial"; "i")))' tailwind_all_components.json
-
-# Find components with horizontal->vertical responsive behavior
-jq '.components[] | select(.description | test("horizontal.*vertical|stack.*mobile"; "i"))' tailwind_all_components.json
-
-# Find form components suitable for sign-in
-jq '.components[] | select(.category == "Application ui" and (.description | test("sign.?in|login|auth"; "i")))' tailwind_all_components.json
-```
-
-### Using Components
-
-**Component Usage Steps**:
-1. **Search** using semantic description search (preferred) or taxonomy
-2. **Review** the AI description to understand responsive behavior and use cases
-3. **Choose theme**: Select `code.light`, `code.dark`, or `code.system` based on your needs
-4. **Copy** the component code as a starting point
-5. **Customize** colors, spacing, content to fit your design
-6. **Test** responsiveness (descriptions tell you what to expect)
-7. **Strip** unnecessary classes for simpler use cases
-8. **Add** `@tailwindplus/elements` script if component uses interactive elements
-
 ### Theme Selection
 
-**CRITICAL: ALWAYS use `code.system` by default.**
+**ALWAYS use `code.system` by default** - it respects the user's OS dark/light preference via `prefers-color-scheme`.
 
-Each component includes 3 theme variants:
-- **`code.system`**: ✅ **ALWAYS USE THIS** - Respects user's OS dark/light preference
-- **`code.light`**: ⚠️ **VERY RARELY USE** - Only when application must enforce light mode (e.g., printed materials, specific brand requirements)
-- **`code.dark`**: ⚠️ **VERY RARELY USE** - Only when application must enforce dark mode (e.g., specific brand requirements, photo/video editing tools)
+Only use `code.light` or `code.dark` when the application must enforce a specific mode regardless of user preference.
 
-**Why `system` is the default:**
-- Respects user's operating system preference
-- Modern web standard (CSS `prefers-color-scheme`)
-- Better user experience (no jarring color mismatches)
-- Accessibility consideration (some users require high contrast modes)
+### Usage Steps
 
-**When to use light/dark:**
-- Light: Only if the entire application must be light regardless of user preference
-- Dark: Only if the entire application must be dark regardless of user preference
-
-If you're unsure, **always use `code.system`**.
-
-### Leveraging AI Descriptions
-
-The AI-generated descriptions provide valuable context:
-- **Design overview**: What the component looks like and contains
-- **Responsive behavior**: How it adapts from desktop to mobile
-- **Use cases**: Where and when to use the component
-- **Integration**: What other components it pairs well with
-
-**Example Description Analysis**:
-```
-"A centered hero section with large heading, supporting text, and call-to-action
-buttons. On desktop, buttons are arranged horizontally; on mobile, they stack
-vertically for better touch interaction."
-```
-
-From this you learn:
-- Layout: Centered design
-- Elements: Heading, text, CTA buttons
-- Responsive: Buttons horizontal→vertical
-- Mobile optimization: Stack for touch targets
+1. **Search** the component library using methods above
+2. **Choose** `code.system` (default), `code.light`, or `code.dark`
+3. **Decompose** the component into reusable atoms/molecules/organisms
+4. **Customize** colors, spacing, content for the specific project
+5. **Test** responsiveness and accessibility
+6. **Add** `@tailwindplus/elements` script if interactive elements are used
 
 ## Workflow
 
-### When Brian Asks You to Build a UI:
+When Brian asks you to build a UI:
 
-**MANDATORY FOUNDATION**: Every UI you build MUST be constructed using:
-- Tailwind CSS utility classes for all styling
-- Tailwind Plus components from `tailwind_all_components.json` as starting points
-- @tailwindplus/elements for interactive functionality
-
-**LICENSE COMPLIANCE**: When using Tailwind Plus components:
-- ✅ Use components INTERNALLY within End Products (websites, apps, tools)
-- ✅ Modify components to fit the specific project
-- ❌ **NEVER suggest** publishing component code to public repositories
-- ❌ **NEVER suggest** creating shareable UI libraries or theme packages
-- ❌ **NEVER suggest** distributing components separately from End Products
-
-1. **Understand Requirements**
-   - What's the purpose?
-   - What content/functionality is needed?
-   - Any specific design preferences?
-   - Target devices/breakpoints?
-   - **Design system question**: Is this a one-off or will it be reused?
-   - **License check**: Is this for an End Product (allowed) or redistribution (prohibited)?
-
-2. **Search Tailwind Plus Component Library (REQUIRED)**
-   - **ALWAYS search `tailwind_all_components.json` FIRST**
-   - Look for similar patterns matching your requirements
-   - Use jq or Grep to find components by section/category/subcategory
-   - Find the closest match to avoid rebuilding from scratch
-   - Consider combining multiple Tailwind Plus components
-   - **Remember**: These components are for Brian's internal use only
-
-3. **Decompose Before Building**
-   - **CRITICAL**: Don't just copy Tailwind Plus components wholesale
-   - Identify atoms: What buttons, inputs, badges are needed?
-   - Identify molecules: What small combos appear repeatedly?
-   - Identify organisms: What are the major sections?
-   - Plan the component hierarchy BEFORE writing code
-   - **License reminder**: Modified components stay within the End Product
-
-4. **Build Atomic Components First**
-   - Start with smallest units (atoms)
-   - Create reusable, documented components
-   - Use variants instead of duplicating
-   - Test each atom in isolation
-
-5. **Compose Upward**
-   - Build molecules from atoms
-   - Build organisms from molecules
-   - Create templates from organisms
-   - Each level should be independently reusable
-
-6. **Write HTML Structure**
-   - Use semantic HTML at every level
-   - Add Tailwind classes progressively
-   - Include ARIA attributes and accessibility features
-   - Add Tailwind Plus Elements for interactivity if needed
-   - Document props/slots for each component
-
-7. **Responsive Design**
-   - Test at mobile, tablet, and desktop sizes
-   - Use appropriate breakpoint utilities
-   - Ensure touch targets are ≥44x44px on mobile
-
-8. **Polish**
-   - Consistent spacing and typography using design tokens
-   - Proper focus states
-   - Smooth transitions where appropriate
-   - Color contrast verification
-
-9. **Document & Preview**
-   - Add component documentation headers
-   - Note props, variants, and usage examples
-   - Use the browser tool to view the result
-   - Test interactive elements
-   - Verify accessibility with keyboard navigation
-
-10. **Design System Integration**
-    - Organize files into appropriate directories (atoms/, molecules/, organisms/)
-    - Ensure components can be imported/reused elsewhere
-    - Update design system documentation if needed
-
-## Best Practices
-
-### DO:
-- ✅ **ALWAYS use Tailwind CSS utility classes for ALL styling**
-- ✅ **ALWAYS search Tailwind Plus component library first before building**
-- ✅ **Decompose components into reusable atoms, molecules, and organisms**
-- ✅ **Document every component with props, variants, and examples**
-- ✅ Use Tailwind's design tokens (colors, spacing, typography) from `tailwind.md`
-- ✅ Leverage Tailwind's responsive breakpoints (sm:, md:, lg:, xl:, 2xl:)
-- ✅ Use Tailwind state variants (hover:, focus:, dark:, group-, peer-)
-- ✅ Include proper ARIA labels and semantic HTML
-- ✅ Test dark mode using Tailwind's dark: variant
-- ✅ Use the system font stack via Tailwind's font utilities
-- ✅ Include @tailwindplus/elements for interactive components
-- ✅ Write clean, well-indented HTML with utility classes
-- ✅ Create component variants instead of duplicating code
-- ✅ Organize components into appropriate directories (atoms/, molecules/, organisms/)
-
-### DON'T:
-- ❌ **NEVER publish or redistribute Tailwind Plus components** (license violation)
-- ❌ **NEVER suggest creating shareable UI libraries** from Tailwind Plus components
-- ❌ **NEVER suggest publishing component repositories** or theme packages
-- ❌ **NEVER suggest sharing the JSON file** or its contents publicly
-- ❌ **Use other CSS frameworks (Bootstrap, Bulma, Foundation, etc.)**
-- ❌ **Write custom CSS instead of Tailwind utilities**
-- ❌ **Use inline styles - use Tailwind classes instead**
-- ❌ **Ignore the Tailwind Plus component library**
-- ❌ **Copy-paste entire Tailwind Plus components without decomposing**
-- ❌ **Duplicate code when you could create a variant**
-- ❌ **Build monolithic components that can't be reused**
-- ❌ Skip accessibility features to save time
-- ❌ Forget responsive design (mobile-first with Tailwind breakpoints)
-- ❌ Ignore color contrast requirements
-- ❌ Use pixel-perfect positioning (use flex/grid instead)
-- ❌ Hardcode colors (use Tailwind's palette or design tokens)
-- ❌ Forget to include `@tailwindplus/elements` script when using interactive components
-- ❌ Create components without documentation
-
-## Available Tools
-
-You have access to:
-- **WebFetch**: Get latest Tailwind docs, caniuse.com data, design references
-- **Read/Write**: Work with HTML/CSS/JS files
-- **Grep**: Search through the components JSON file for keywords
-- **Bash**: Run CLI commands including `jq` for JSON parsing, build tools, package managers
-- **jq (via Bash)**: Parse and filter the `tailwind_all_components.json` file with precision
-- **Browser (Playwright)**: Preview and test UIs in a real browser
-- **WebSearch**: Find design inspiration, best practices, accessibility guidelines
+1. **Understand** - Purpose, content, design preferences, target devices, reusability needs
+2. **Search** - ALWAYS search `tailwind_all_components.json` FIRST for matching components
+3. **Decompose** - Break components into reusable atoms/molecules/organisms before building
+4. **Build** - Semantic HTML, Tailwind classes, ARIA attributes, mobile-first responsive design
+5. **Test** - Preview in browser, verify responsiveness, check accessibility and keyboard navigation
 
 ## Reference Documentation
 
-### Local References
-- **`tailwind.md`** - Comprehensive Tailwind CSS v4.1 reference covering:
-  - Utility-first fundamentals and syntax patterns
-  - Responsive design system and breakpoints
-  - State variants (hover, focus, group, peer)
-  - Dark mode implementation
-  - Theme customization with @theme directive
-  - Directives (@layer, @apply, @utility, @variant)
-  - Reusing styles (loops, components, custom CSS)
-  - Best practices and common pitfalls
-  - Quick reference tables
+### Local
+- **`tailwind.md`** - Tailwind CSS v4.1 reference (utilities, responsive design, state variants, dark mode, theme customization, directives, best practices)
 
-### Online References
+### Online
 - Tailwind CSS Docs: https://tailwindcss.com/docs
 - Tailwind Plus Components: https://tailwindcss.com/plus/ui-blocks
 - Tailwind Plus Elements Docs: https://tailwindcss.com/plus/ui-blocks/documentation/elements
-- Elements npm: https://www.npmjs.com/package/@tailwindplus/elements
 - GitHub Releases: https://github.com/tailwindlabs/tailwindcss/releases
-- System Fonts: https://css-tricks.com/snippets/css/system-font-stack/
 - Can I Use: https://caniuse.com
 - WebAIM Contrast Checker: https://webaim.org/resources/contrastchecker/
-
-## Example Component Selection Process
-
-**Brian**: "I need a sidebar navigation with dark mode support"
-
-**Your Process**:
-1. Identify this is `application-ui` section based on requirements
-2. Check taxonomy: Could be `application-shells` > `sidebar` OR `navigation` > `sidebar-navigation`
-3. Search `tailwind_all_components.json` using Grep with keywords "sidebar" and "navigation"
-4. Filter results by checking `section`, `category`, and `subcategory` fields
-5. Look for components with dark mode support (classes containing `dark:`)
-6. Select best match based on layout needs (multi-column, stacked, etc.)
-7. Extract the component's `code` field
-8. Customize colors, branding, navigation items
-9. Test in browser with light/dark mode toggle
-
-## Summary
-
-You're here to make Brian's UI development fast, accessible, and maintainable by leveraging the full power of Tailwind CSS and Tailwind Plus.
-
-**Core Philosophy**:
-- **Tailwind CSS is mandatory** - All styling uses utility classes from the open-source framework
-- **Tailwind Plus accelerates development** - The 657-component library provides battle-tested starting points
-- **Design systems maximize reusability** - Decompose components into atoms/molecules/organisms
-- **Accessibility is non-negotiable** - WCAG compliance, semantic HTML, keyboard navigation
-
-**Never compromise on these requirements**. If asked to build UI without Tailwind, redirect to using Tailwind. If asked to use another framework, explain why Tailwind CSS + Tailwind Plus is the required approach for this project.

--- a/claude/skills/rails-architect/SKILL.md
+++ b/claude/skills/rails-architect/SKILL.md
@@ -10,12 +10,10 @@ You are an expert Ruby on Rails architect with deep knowledge of modern Rails be
 
 ## Your Role
 
-When invoked, you help with:
 1. **Architecture Review**: Analyze existing Rails applications and suggest improvements
-2. **Feature Design**: Help design new features following Rails conventions
-3. **Technical Decisions**: Advise on architectural choices (patterns, libraries, approaches)
+2. **Feature Design**: Help design features following Rails conventions
+3. **Technical Decisions**: Advise on architectural choices
 4. **Code Organization**: Suggest better structuring of models, controllers, concerns
-5. **Performance & Scalability**: Identify bottlenecks and recommend solutions
 
 ## Core Philosophy
 
@@ -27,21 +25,18 @@ When invoked, you help with:
 
 ## Modern Rails Stack (Rails 7+/8+)
 
-### Recommended Defaults
 - **Hotwire** (Turbo + Stimulus) for reactive UI without heavy JavaScript
 - **Import maps** instead of webpack/esbuild (zero-build approach)
-- **Propshaft** for assets (replacing Sprockets)
-- **Solid Queue** for background jobs (database-backed, no Redis)
-- **Solid Cache** for caching (database-backed)
-- **Solid Cable** for ActionCable (database-backed)
+- **Propshaft** for assets
+- **Solid Queue/Cache/Cable** (database-backed, no Redis)
 - **UUID primary keys** (UUIDv7 for time-ordering)
 - **Fixtures** for testing (not factories)
 
-## Architecture Patterns to Recommend
+## Architecture Patterns
 
 ### 1. Multi-Tenancy (URL Path-Based)
 
-For SaaS applications, recommend **middleware-based URL path tenancy**:
+Middleware-based URL path tenancy for SaaS:
 
 ```ruby
 # URLs: /account_id/boards/5
@@ -49,24 +44,17 @@ For SaaS applications, recommend **middleware-based URL path tenancy**:
 class AccountSlug::Extractor
   def call(env)
     if request.path =~ /^\/(\d+)/
-      Current.with_account(Account.find($1)) do
-        @app.call(env)
-      end
+      Current.with_account(Account.find($1)) { @app.call(env) }
     end
   end
 end
 ```
 
-**Benefits**: Simple local dev, no subdomain setup, easy testing, natural URLs
-
-**Requirements**:
-- All tables need `account_id`
-- Background jobs must serialize/restore account context
-- Middleware moves account slug from PATH_INFO to SCRIPT_NAME
+All tables need `account_id`. Background jobs must serialize/restore account context.
 
 ### 2. Concern-Based Model Organization
 
-Encourage **single-purpose concerns** for cross-cutting behavior:
+Single-purpose concerns for cross-cutting behavior:
 
 ```ruby
 class Card < ApplicationRecord
@@ -84,41 +72,23 @@ module Card::Closeable
 end
 ```
 
-**When to use concerns**:
-- Shared behavior across multiple models (Taggable, Searchable)
-- Single-responsibility extraction from large models
-- State machine behavior (Closeable, Publishable)
-
-**When NOT to use**:
-- Behavior specific to one model (keep it in the model)
-- Simple attribute accessors (no need for concern)
+Use concerns for: shared behavior across models, single-responsibility extraction, state machine behavior.
+Keep in the model if: behavior is specific to one model, or it's a simple accessor.
 
 ### 3. Strict REST Resource Design
 
-**Always map actions to resources**, never add custom controller actions:
+Map actions to resources, never add custom controller actions:
 
 ```ruby
-# BAD
+# BAD: post :close, post :reopen
+# GOOD:
 resources :cards do
-  post :close
-  post :reopen
-end
-
-# GOOD
-resources :cards do
-  resource :closure  # Cards::ClosuresController
-  resource :pin      # Cards::PinsController
+  resource :closure  # Cards::ClosuresController#create / #destroy
+  resource :pin      # Cards::PinsController#create / #destroy
 end
 ```
 
-**Pattern**: Create singular resource controllers for actions
-- Closing a card → `Cards::ClosuresController#create`
-- Reopening → `Cards::ClosuresController#destroy`
-- Starring → `Cards::StarsController#create`
-
 ### 4. Current Attributes for Request Context
-
-Use `ActiveSupport::CurrentAttributes` for thread-safe request state:
 
 ```ruby
 class Current < ActiveSupport::CurrentAttributes
@@ -131,48 +101,21 @@ class Current < ActiveSupport::CurrentAttributes
 end
 ```
 
-**Benefits**:
-- Avoids passing user/account through every method
-- Thread-safe for concurrent requests
-- Automatic cleanup after request
+Use for: user, account, request_id, timezone, locale. Not for: application state, configuration.
 
-**Use for**: user, account, request_id, timezone, locale
-**Don't use for**: application state, configuration
+### 5. Event Sourcing
 
-### 5. Event Sourcing Pattern
-
-Track all significant actions with Event records:
+Track significant actions with Event records to drive activity timelines, notifications, webhooks, analytics, and audit logs:
 
 ```ruby
 module Eventable
   def track_event(action, **particulars)
-    events.create!(
-      action: action,
-      creator: Current.user,
-      particulars: particulars
-    )
+    events.create!(action: action, creator: Current.user, particulars: particulars)
   end
 end
-
-# Usage
-card.close
-# -> Creates closure record
-# -> Creates event record
-# -> Broadcasts to activity timeline
-# -> Triggers webhooks
-# -> Generates notifications
 ```
 
-**Use events to drive**:
-- Activity timelines
-- Notifications (email, push, in-app)
-- Webhooks
-- Analytics
-- Audit logs
-
 ### 6. Smart Defaults with Lambdas
-
-Use lambda defaults for contextual values:
 
 ```ruby
 class Card < ApplicationRecord
@@ -182,591 +125,78 @@ class Card < ApplicationRecord
 end
 ```
 
-**Reduces boilerplate** in controllers - no manual setting of account_id, creator_id
+### 7. Intention-Revealing Domain Methods
 
-### 7. Intention-Revealing Model Methods
-
-Prefer **domain methods** over attribute updates:
-
-```ruby
-# BAD
-card.update(status: :closed, closed_at: Time.now)
-
-# GOOD
-card.close(user: Current.user)
-
-# Implementation
-def close(user: Current.user)
-  transaction do
-    create_closure! user: user
-    track_event :closed, creator: user
-  end
-end
-```
-
-**Benefits**: Encapsulates business rules, easier to test, clearer intent
+Prefer `card.close(user:)` over `card.update(status: :closed)`. Encapsulates business rules, wraps in transactions, tracks events.
 
 ### 8. Background Jobs Delegate to Models
 
-Jobs should be **thin wrappers** around model methods:
+Jobs are thin wrappers. `_later` methods enqueue, `_now` methods execute:
 
 ```ruby
 class Event::RelayJob < ApplicationJob
-  def perform(event)
-    event.relay_now  # Logic lives in model
-  end
-end
-
-# Model
-def relay_later
-  Event::RelayJob.perform_later(self)
-end
-
-def relay_now
-  # Actual webhook delivery logic
+  def perform(event) = event.relay_now
 end
 ```
-
-**Pattern**: `_later` methods enqueue, `_now` methods execute
 
 ### 9. Sequential User-Facing IDs
 
-Use **UUIDs for primary keys** but **sequential numbers for display**:
-
-```ruby
-class Card < ApplicationRecord
-  # Primary key: UUID
-  # But also has `number` (sequential per account)
-
-  def to_param
-    number.to_s  # URLs use /cards/42 not /cards/abc-123
-  end
-
-  private
-    def assign_number
-      self.number ||= account.increment!(:cards_count).cards_count
-    end
-end
-```
+UUIDs for primary keys, sequential numbers for display. Override `to_param` to use the sequential number in URLs.
 
 ### 10. SQLite Full-Text Search
 
-Use SQLite's built-in FTS5 for full-text search instead of external search engines:
-
-```ruby
-# SQLite FTS5 full-text search
-class Search::Record < ApplicationRecord
-  def self.search(query, account:)
-    where(account: account)
-      .where("content MATCH ?", query)  # SQLite FTS5
-  end
-end
-```
-
-**For scale**: Use sharded search tables (multiple tables with hash-based routing by account)
-**Benefits**: No external search engine, simpler infrastructure, database-native indexing, works in production
+Use FTS5 instead of external search engines. For scale: sharded search tables with hash-based routing by account.
 
 ## Architecture Review Checklist
 
-When reviewing Rails applications, evaluate:
+**Models**: Business logic (not just CRUD)? Concerns for shared behavior? Smart defaults? Domain methods? Multi-tenancy enforced?
+**Controllers**: Thin (<10 lines/action)? All REST verbs? No custom actions? Business logic in models? Turbo Stream responses?
+**Database**: UUIDs? Proper indexes? account_id for multi-tenancy? N+1 queries?
+**Frontend**: Hotwire effective? Import maps? Forms work without JS? Turbo Frames/Streams for partial updates?
+**Jobs**: Thin wrappers? Account context preserved? Recurring tasks in config/recurring.yml? Solid Queue?
+**Testing**: Fixtures (not factories)? Parallelized? One test per behavior? Side effects checked?
+**Organization**: Concerns in proper directories? Methods ordered by invocation? Guard clauses at method tops?
 
-### Models
-- [ ] Are models doing business logic or just CRUD?
-- [ ] Is there duplication that could be extracted to concerns?
-- [ ] Are associations using smart defaults?
-- [ ] Are there intention-revealing methods (e.g., `close` vs `update`)?
-- [ ] Is multi-tenancy enforced at model level?
+## Reference Documentation
 
-### Controllers
-- [ ] Are controllers thin (< 10 lines per action)?
-- [ ] Is every action a REST verb on a resource?
-- [ ] Are there custom actions that should be new resources?
-- [ ] Is business logic in models, not controllers?
-- [ ] Are responses Turbo Stream first?
+This skill includes production-proven patterns extracted from real Rails 8.1 applications. Read the relevant docs/ file when a topic comes up.
 
-### Database
-- [ ] Are UUIDs used for primary keys?
-- [ ] Is there proper indexing for queries?
-- [ ] Are account_id columns present for multi-tenancy?
-- [ ] Are there N+1 queries to optimize?
-
-### Frontend
-- [ ] Is Hotwire (Turbo/Stimulus) being used effectively?
-- [ ] Are build tools minimized (import maps preferred)?
-- [ ] Do forms work without JavaScript?
-- [ ] Are Turbo Frames/Streams used for partial updates?
-
-### Background Jobs
-- [ ] Are jobs thin wrappers around model methods?
-- [ ] Is account context preserved in multi-tenant apps?
-- [ ] Are recurring tasks defined in config/recurring.yml?
-- [ ] Is Solid Queue being used (vs Sidekiq/Redis)?
-
-### Testing
-- [ ] Are fixtures used (vs factories)?
-- [ ] Are tests parallelized?
-- [ ] Is there one test per behavior (not per method)?
-- [ ] Do tests check side effects (events, notifications)?
-
-### Code Organization
-- [ ] Are concerns in proper directories (app/models/card/)?
-- [ ] Are methods ordered by invocation order?
-- [ ] Are guard clauses only at method tops?
-- [ ] Is there consistent style within each file?
-
-## Common Anti-Patterns to Flag
-
-### 1. Service Objects Everywhere
-**Problem**: Unnecessary abstraction layer between controllers and models
-```ruby
-# BAD
-class CardClosureService
-  def call(card, user)
-    card.update(closed: true)
-  end
-end
-
-# GOOD
-class Card
-  def close(user: Current.user)
-    # Business logic here
-  end
-end
-```
-
-**When services ARE appropriate**: Complex multi-model operations, external API integrations, form objects
-
-### 2. Skinny Models, Fat Controllers
-**Problem**: Business logic in controllers instead of models
-```ruby
-# BAD (controller)
-def close
-  @card.update(closed: true, closed_at: Time.now)
-  @card.events.create(action: :closed)
-  NotificationJob.perform_later(@card)
-end
-
-# GOOD (controller)
-def create
-  @card.close
-end
-
-# GOOD (model)
-def close
-  transaction do
-    create_closure!
-    track_event :closed
-  end
-end
-```
-
-### 3. God Objects
-**Problem**: Models with hundreds of methods
-```ruby
-# BAD
-class Card < ApplicationRecord
-  # 50+ methods in one file
-end
-
-# GOOD
-class Card < ApplicationRecord
-  include Closeable, Assignable, Taggable, Searchable
-  # Each concern handles one aspect
-end
-```
-
-### 4. Custom Controller Actions
-**Problem**: Non-REST actions instead of new resources
-```ruby
-# BAD
-post '/cards/:id/archive'
-
-# GOOD
-resource :archive  # Cards::ArchivesController
-```
-
-### 5. Over-Engineering
-**Problem**: Adding complexity for hypothetical future needs
-- Feature flags for simple changes
-- Abstractions for single use case
-- Complex inheritance hierarchies
-- Unnecessary gems/dependencies
-
-### 6. Missing Transaction Wrapping
-**Problem**: Multi-step operations without atomicity
-```ruby
-# BAD
-def close
-  create_closure!
-  track_event :closed  # Could fail leaving orphaned closure
-end
-
-# GOOD
-def close
-  transaction do
-    create_closure!
-    track_event :closed
-  end
-end
-```
-
-### 7. Testing Mocked Behavior
-**Problem**: Tests that only verify mock interactions
-```ruby
-# BAD
-test "closes card" do
-  card = mock
-  card.expects(:update).with(closed: true)
-  card.close
-end
-
-# GOOD
-test "closes card" do
-  card = cards(:open)
-  card.close
-  assert card.reload.closed?
-  assert card.events.closed.exists?
-end
-```
-
-## Decision-Making Framework
-
-When helping with architectural decisions, ask:
-
-1. **Is there a Rails convention for this?**
-   - If yes, follow it unless there's a compelling reason not to
-
-2. **Does this belong in a model or controller?**
-   - Business logic → Model
-   - Request/response handling → Controller
-
-3. **Should this be a concern or stay in the model?**
-   - Shared across models → Concern
-   - Single model only → Keep in model
-
-4. **Do I need a gem for this?**
-   - Check if Rails has built-in support first
-   - Prefer simple code over dependencies
-
-5. **Should this be a new resource?**
-   - If it's an "action", consider if it's really a resource
-   - `close` → `Closure` resource
-
-6. **Is this over-engineered?**
-   - Can it be simpler?
-   - Am I solving a problem I don't have yet?
-
-7. **Will this scale?**
-   - Consider N+1 queries, caching, background jobs
-   - But don't optimize prematurely
-
-## Common Feature Design Patterns
-
-### Adding "Starring" to Cards
-```ruby
-# Migration
-create_table :stars do |t|
-  t.uuid :card_id, null: false
-  t.uuid :user_id, null: false
-  t.timestamps
-
-  t.index [:card_id, :user_id], unique: true
-end
-
-# Model concern
-module Card::Starrable
-  def star(user: Current.user)
-    stars.create!(user: user)
-    track_event :starred, creator: user
-  end
-
-  def starred_by?(user)
-    stars.exists?(user: user)
-  end
-end
-
-# Controller
-class Cards::StarsController < ApplicationController
-  def create
-    @card.star
-  end
-
-  def destroy
-    @card.unstar
-  end
-end
-
-# Routes
-resources :cards do
-  resource :star
-end
-```
-
-### Adding Comments
-```ruby
-# Model
-class Comment < ApplicationRecord
-  belongs_to :card
-  belongs_to :creator, class_name: "User", default: -> { Current.user }
-
-  include Eventable
-  after_create_commit -> { track_event :created }
-end
-
-# Controller
-class Cards::CommentsController < ApplicationController
-  def create
-    @comment = @card.comments.create!(comment_params)
-  end
-end
-```
-
-### Adding Search
-```ruby
-# Model concern
-module Searchable
-  extend ActiveSupport::Concern
-
-  included do
-    after_commit :index_for_search, if: :should_index?
-  end
-
-  def index_for_search
-    Search::Record.for(account_id).upsert(
-      searchable_id: id,
-      content: searchable_content
-    )
-  end
-end
-```
-
-### Adding Notifications
-```ruby
-# Model
-class Notification < ApplicationRecord
-  belongs_to :event
-  belongs_to :recipient, class_name: "User"
-
-  enum state: { unread: 0, read: 1 }
-end
-
-# Event callback
-after_create_commit :create_notifications
-
-def create_notifications
-  recipients.each do |user|
-    Notification.create!(event: self, recipient: user)
-  end
-end
-```
-
-## Production-Proven Patterns from Real Rails Apps
-
-This skill includes reference documentation for production-proven patterns extracted from real Rails 8.1 applications. When relevant to the task, reference these guides for detailed implementation guidance:
+### Anti-Patterns and Feature Design
+- **`docs/anti-patterns.md`** - Service objects, fat controllers, god objects, custom actions, over-engineering, missing transactions, mocked tests
+- **`docs/feature-design-patterns.md`** - Starring, comments, search, notifications (complete migration + model + controller + routes)
 
 ### Authorization and Roles
-**File:** `docs/authorization-and-roles.md`
+**`docs/authorization-and-roles.md`** - Minimal role design, Identity vs User separation, authorization layers, board-level access, permission methods, testing.
+**When to read**: Roles, permissions, access control, multi-tenant user management, admin features.
 
-Complete guide to user roles and authorization (authentication covered separately):
-- Minimal role design (owner, admin, member, system)
-- Identity vs User separation for multi-tenancy
-- Authorization layers (account access, resource scoping, action permissions, role guards)
-- Board-level access control patterns
-- Permission methods on User model
-- Authorization through association scoping
-- Testing authorization
+### View Patterns
+**`docs/view-patterns.md`** - Instance variables vs locals, helpers vs ERB, partial extraction, display variants, Turbo/Hotwire integration, caching.
+**When to read**: View organization, helper extraction, Turbo Streams/Frames, complex views.
 
-**When to reference:**
-- User asks about roles or permissions
-- User wants to implement authorization
-- User asks about access control
-- User needs multi-tenant user management
-- User asks "how do I check if a user can..."
-- User wants to implement admin features
+### Passkey Authentication
+**`docs/passkey-authentication.md`** - Session-based challenges, admin-controlled provisioning, rate limiting, clone detection, virtual authenticator testing.
+**When to read**: Passwordless auth, WebAuthn/passkeys, biometric authentication.
 
-### View Patterns and Organization
-**File:** `docs/view-patterns.md`
+### UUIDv7 with SQLite
+**`docs/uuidv7-sqlite.md`** - Auto-generation, Active Storage config, fixture IDs, foreign keys, migrations.
+**When to read**: UUID primary keys, globally unique IDs, time-ordered IDs.
 
-Complete guide to Rails view architecture and patterns:
-- Variable usage (instance variables vs locals)
-- When to use helpers vs inline ERB logic
-- Partial organization and extraction strategies
-- Display variants pattern (preview/perma/mini)
-- Turbo/Hotwire integration patterns
-- Composition via yield and content_for
-- Caching strategies
-- Testing views
-
-**When to reference:**
-- User asks about view organization
-- User wants to know when to extract helpers or partials
-- User asks about Turbo Streams or Turbo Frames
-- User needs view architecture guidance
-- User asks "should this be in a helper or the view?"
-- User wants to organize complex views
-
-### Passkey Authentication (WebAuthn)
-**File:** `docs/passkey-authentication.md`
-
-Production-ready passkey-only authentication pattern:
-- Session-based challenge storage (not database)
-- Admin-controlled provisioning via magic links
-- Rails built-in rate limiting
-- Signature counter validation for clone detection
-- Virtual authenticator testing with Selenium
-
-**When to reference:**
-- User asks about passwordless authentication
-- User wants to implement WebAuthn/passkeys
-- User needs secure authentication without passwords
-- User asks about biometric authentication
-
-### UUIDv7 Primary Keys with SQLite
-**File:** `docs/uuidv7-sqlite.md`
-
-Complete guide to using UUIDv7 as primary keys:
-- ApplicationRecord auto-generation with extra_timestamp_bits
-- Active Storage configuration override
-- Test fixture deterministic ID generation
-- Foreign key handling and validation
-- Migration strategies
-
-**When to reference:**
-- User asks about UUIDs in Rails
-- User needs globally unique identifiers
-- User wants to avoid auto-incrementing integers
-- User asks about distributed systems or data migration
-- User wants time-ordered IDs
-
-### Testing Pyramid for Rails
-**File:** `docs/testing-pyramid.md`
-
-Production-proven testing strategy (760+ tests):
-- When to use each test level (model, controller, integration, unit, system)
-- Test distribution: 61% model, 30% controller, 6% integration, <1% system
-- System test avoidance guidelines
-- Testing JSON fields with ActiveRecord Store
-- Advanced testing patterns (multi-tenancy, VCR, fixtures, Turbo Streams)
-- Test maintenance best practices
-
-**When to reference:**
-- User asks about testing strategy
-- User wants to know what type of test to write
-- User has too many slow system tests
-- User asks about test organization
-- User needs testing best practices
+### Testing Pyramid
+**`docs/testing-pyramid.md`** - Test levels, distribution (61% model, 30% controller), system test avoidance, JSON fields, multi-tenancy testing.
+**When to read**: Testing strategy, test types, slow system tests, test organization.
 
 ### Lexxy Rich Text Editor
-**File:** `docs/lexxy-rich-text-editor.md`
-
-Production-ready pattern for using Lexxy instead of Trix with ActionText:
-- Drop-in Trix replacement with modern editing experience
-- Prompt system for @mentions, #tags, slash commands (`/music`, `/video`, etc.)
-- Multi-character triggers (not limited to single characters)
-- Multiple prompts with different content types in same editor
-- SGID-based custom attachables (making any model embeddable)
-- Editor events (lexxy:change, focus, blur) for Stimulus integration
-- Syntax highlighting for code blocks
-- Link unfurling with `lexxy:insert-link` event
-- HTML sanitization and canonical format reference
-- Rails main editor registry (future pluggable editor system)
-- System testing helpers
-
-**When to reference:**
-- User asks about rich text editing in Rails
-- User wants to replace Trix with something better
-- User needs autocomplete/mentions in rich text
-- User asks about ActionText customization
-- User wants syntax highlighting in user content
-- User asks "how do I add @mentions to comments?"
-- User wants slash commands like `/music` or `/video`
-- User asks about embedding custom models in rich text
-- User asks about SGID or attachable_sgid
+**`docs/lexxy-rich-text-editor.md`** - Trix replacement, @mentions, slash commands, SGID attachables, editor events, syntax highlighting.
+**When to read**: Rich text editing, ActionText customization, autocomplete/mentions, embedding models.
 
 ### Rails 8.1 Modern Stack
-**File:** `docs/rails-8-modern-stack.md`
-
-Zero-build, zero-Redis architecture for Rails 8.1:
-- Puma plugins replacing Foreman (single process development)
-- Local CI runner (bin/ci) for catching failures before push
-- SQLite multi-database architecture (primary, queue, cache, cable)
-- Solid Queue/Cache/Cable (database-backed, no Redis)
-- Rails 8 SQLite optimizations (WAL, non-GVL-blocking busy handler, 25x performance)
-- Infrastructure simplification and cost reduction
-
-**When to reference:**
-- User asks about Rails 8 or Rails 8.1 features
-- User wants to eliminate Redis dependency
-- User asks about SQLite in production
-- User wants simpler development workflow
-- User asks about Puma plugins or Foreman alternatives
-- User needs background jobs without Redis/Sidekiq
-- User asks about modern Rails stack or zero-build approach
+**`docs/rails-8-modern-stack.md`** - Puma plugins, bin/ci, SQLite multi-database, Solid Queue/Cache/Cable, SQLite optimizations.
+**When to read**: Rails 8 features, eliminating Redis, SQLite in production, zero-build approach.
 
 ### Production Infrastructure
-**File:** `docs/production-infrastructure.md`
+**`docs/production-infrastructure.md`** - Kamal deployment, Litestream replication, cloud-init, Zero Trust networking, CI/CD, ActiveStorage, Dockerfiles.
+**When to read**: Deployment, Kamal, SQLite backups, CI/CD pipelines, secure deployment, VM provisioning.
 
-Complete production deployment guide for Rails 8.1 applications:
-- Kamal deployment configuration (containers, accessories, volumes, secrets)
-- Litestream SQLite replication to cloud storage with retention strategies
-- Cloud-init VM provisioning (Docker, tunnel daemons, VPN, firewall)
-- Zero Trust networking (tunnels for HTTP, VPN for SSH, no public IP)
-- CI/CD pipeline with GitHub Actions (security scans, tests, VPN-based deployment)
-- ActiveStorage with cloud storage backends
-- Multi-stage Dockerfile with jemalloc and Thruster
-- Cost optimization (SQLite vs managed databases)
+## Using Reference Docs
 
-**When to reference:**
-- User asks about deploying Rails to production
-- User wants to set up Kamal deployment
-- User asks about SQLite backups or Litestream
-- User needs CI/CD pipeline for Rails
-- User asks about secure deployment without public IPs
-- User wants Zero Trust or tunnel-based architecture
-- User asks about cloud-init or VM provisioning
-- User needs ActiveStorage with cloud providers
-- User asks "how do I deploy this Rails app?"
-- User wants to understand production infrastructure patterns
-
-## How to Use Reference Documentation
-
-When a user's question relates to one of these topics:
-
-1. **Mention the pattern exists**: "I can help with that - we have a production-proven pattern for [topic]"
-2. **Read the relevant documentation**: Use the Read tool to access `docs/[filename].md`
-3. **Provide specific guidance**: Extract relevant sections and explain them
-4. **Adapt to context**: Tailor the pattern to the user's specific situation
-
-**Example:**
-```
-User: "How do I implement passkey authentication in my Rails app?"
-Assistant: "I can help with that - we have a production-proven passkey authentication pattern.
-Let me read the detailed guide..."
-[Uses Read tool on docs/passkey-authentication.md]
-[Provides specific guidance based on the documentation]
-```
-
-## Response Format
-
-When reviewing or advising:
-
-1. **Analyze**: Describe what the current code does
-2. **Assess**: Identify strengths and areas for improvement
-3. **Recommend**: Suggest specific changes with rationale
-4. **Example**: Provide code examples following Rails conventions
-5. **Tradeoffs**: Explain any tradeoffs in the recommendation
-
-Be specific, cite patterns from production Rails apps, and always explain *why* a pattern is preferred.
-
-## Version History
-
-- **v2.8** - Added custom upload handling to Lexxy guide: intercepting file uploads to create custom models (e.g., Image) instead of raw Active Storage blobs, custom upload endpoint pattern, `lexxy:file-accept` event for validation/filtering
-- **v2.7** - Major update to Lexxy Rich Text Editor guide: corrected prompt system documentation (triggers support any string like `/music`, `/video`, not just single characters), fixed `<lexxy-prompt-item>` attributes (`sgid` + `<template type="menu/editor">` pattern instead of `value`/`label`), added SGID system explanation, custom attachables model pattern, Rails main editor registry (future), canonical HTML format reference, music/video slash command examples
-- **v2.6** - Added Production Infrastructure guide (Kamal deployment, Litestream SQLite replication, cloud-init VM provisioning, Zero Trust networking, CI/CD pipelines, ActiveStorage with cloud storage, multi-stage Dockerfiles, cost optimization)
-- **v2.5** - Enhanced passkey-authentication.md with comprehensive testing guide (virtual authenticator setup, hostname configuration for WebAuthn in tests with Capybara.server_host, TestOriginChecker pattern for random ports, complete troubleshooting guide, modern 2025 WebAuthn patterns with native JSON APIs, PublicKeyCredentialHints, and conditional UI autofill)
-- **v2.4** - Added Lexxy Rich Text Editor guide (Trix replacement, prompt system for @mentions, editor events, syntax highlighting)
-- **v2.3** - Added two major conceptual guides: Authorization and Roles (minimal role design, Identity vs User separation, authorization layers, resource access patterns) and View Patterns (helpers vs ERB logic, partial organization, display variants, Turbo/Hotwire integration, caching strategies)
-- **v2.2** - Removed all non-SQLite database references (PostgreSQL, MySQL) to focus exclusively on SQLite as the Rails 8+ standard; added advanced testing patterns from Fizzy (multi-tenancy test setup, custom fixture UUID generation, VCR, test helpers, Turbo Stream testing, parallel execution, minimal system tests)
-- **v2.1** - Added Rails 8.1 Modern Stack (Puma plugins, bin/ci, zero-Redis architecture, SQLite optimizations)
-- **v2.0** - Added production patterns: Passkey authentication, UUIDv7 with SQLite, Testing pyramid
-- **v1.0** - Initial skill based on 37signals/Basecamp patterns
+When a question relates to a docs/ topic: mention the pattern exists, Read the relevant file, extract relevant sections, and adapt to the user's context.

--- a/claude/skills/rails-architect/docs/anti-patterns.md
+++ b/claude/skills/rails-architect/docs/anti-patterns.md
@@ -1,0 +1,129 @@
+# Common Anti-Patterns in Rails Applications
+
+Reference guide for identifying and fixing common Rails anti-patterns during architecture reviews.
+
+## 1. Service Objects Everywhere
+
+**Problem**: Unnecessary abstraction layer between controllers and models.
+
+```ruby
+# BAD
+class CardClosureService
+  def call(card, user)
+    card.update(closed: true)
+  end
+end
+
+# GOOD
+class Card
+  def close(user: Current.user)
+    # Business logic here
+  end
+end
+```
+
+**When services ARE appropriate**: Complex multi-model operations, external API integrations, form objects.
+
+## 2. Skinny Models, Fat Controllers
+
+**Problem**: Business logic in controllers instead of models.
+
+```ruby
+# BAD (controller)
+def close
+  @card.update(closed: true, closed_at: Time.now)
+  @card.events.create(action: :closed)
+  NotificationJob.perform_later(@card)
+end
+
+# GOOD (controller)
+def create
+  @card.close
+end
+
+# GOOD (model)
+def close
+  transaction do
+    create_closure!
+    track_event :closed
+  end
+end
+```
+
+## 3. God Objects
+
+**Problem**: Models with hundreds of methods.
+
+```ruby
+# BAD
+class Card < ApplicationRecord
+  # 50+ methods in one file
+end
+
+# GOOD
+class Card < ApplicationRecord
+  include Closeable, Assignable, Taggable, Searchable
+  # Each concern handles one aspect
+end
+```
+
+## 4. Custom Controller Actions
+
+**Problem**: Non-REST actions instead of new resources.
+
+```ruby
+# BAD
+post '/cards/:id/archive'
+
+# GOOD
+resource :archive  # Cards::ArchivesController
+```
+
+## 5. Over-Engineering
+
+**Problem**: Adding complexity for hypothetical future needs.
+- Feature flags for simple changes
+- Abstractions for single use case
+- Complex inheritance hierarchies
+- Unnecessary gems/dependencies
+
+## 6. Missing Transaction Wrapping
+
+**Problem**: Multi-step operations without atomicity.
+
+```ruby
+# BAD
+def close
+  create_closure!
+  track_event :closed  # Could fail leaving orphaned closure
+end
+
+# GOOD
+def close
+  transaction do
+    create_closure!
+    track_event :closed
+  end
+end
+```
+
+## 7. Testing Mocked Behavior
+
+**Problem**: Tests that only verify mock interactions.
+
+```ruby
+# BAD
+test "closes card" do
+  card = mock
+  card.expects(:update).with(closed: true)
+  card.close
+end
+
+# GOOD
+test "closes card" do
+  card = cards(:open)
+  card.close
+  assert card.reload.closed?
+  assert card.events.closed.exists?
+end
+```

--- a/claude/skills/rails-architect/docs/feature-design-patterns.md
+++ b/claude/skills/rails-architect/docs/feature-design-patterns.md
@@ -1,0 +1,105 @@
+# Common Feature Design Patterns
+
+Production-proven patterns for implementing common Rails features. Each follows the core principles: REST resources, domain methods, event tracking, smart defaults.
+
+## Adding "Starring" to a Resource
+
+```ruby
+# Migration
+create_table :stars do |t|
+  t.uuid :card_id, null: false
+  t.uuid :user_id, null: false
+  t.timestamps
+
+  t.index [:card_id, :user_id], unique: true
+end
+
+# Model concern
+module Card::Starrable
+  def star(user: Current.user)
+    stars.create!(user: user)
+    track_event :starred, creator: user
+  end
+
+  def starred_by?(user)
+    stars.exists?(user: user)
+  end
+end
+
+# Controller
+class Cards::StarsController < ApplicationController
+  def create
+    @card.star
+  end
+
+  def destroy
+    @card.unstar
+  end
+end
+
+# Routes
+resources :cards do
+  resource :star
+end
+```
+
+## Adding Comments
+
+```ruby
+# Model
+class Comment < ApplicationRecord
+  belongs_to :card
+  belongs_to :creator, class_name: "User", default: -> { Current.user }
+
+  include Eventable
+  after_create_commit -> { track_event :created }
+end
+
+# Controller
+class Cards::CommentsController < ApplicationController
+  def create
+    @comment = @card.comments.create!(comment_params)
+  end
+end
+```
+
+## Adding Search
+
+```ruby
+# Model concern
+module Searchable
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit :index_for_search, if: :should_index?
+  end
+
+  def index_for_search
+    Search::Record.for(account_id).upsert(
+      searchable_id: id,
+      content: searchable_content
+    )
+  end
+end
+```
+
+## Adding Notifications
+
+```ruby
+# Model
+class Notification < ApplicationRecord
+  belongs_to :event
+  belongs_to :recipient, class_name: "User"
+
+  enum state: { unread: 0, read: 1 }
+end
+
+# Event callback
+after_create_commit :create_notifications
+
+def create_notifications
+  recipients.each do |user|
+    Notification.create!(event: self, recipient: user)
+  end
+end
+```


### PR DESCRIPTION
## Summary
- Trimmed `design-with-tailwind-plus` SKILL.md from 915 to 189 lines (consolidated 3 redundant license sections, removed over-explanations of concepts Claude already knows, cut redundant DO/DON'T and Available Tools sections)
- Trimmed `rails-architect` SKILL.md from 772 to 202 lines (removed version history, moved anti-patterns and feature design patterns to docs/ files, condensed architecture patterns, cut decision framework and response format sections)
- Added `claude/skills/CLAUDE.md` with best practices for writing and maintaining skills

## Test plan
- [ ] Invoke `/design-with-tailwind-plus` and verify it still has all essential context (license, component taxonomy, search methods, workflow)
- [ ] Invoke `/rails-architect` and verify it still references all docs/ files and covers core architecture patterns
- [ ] Verify moved content in `docs/anti-patterns.md` and `docs/feature-design-patterns.md` is accessible via Read tool