### PR TITLE
Update rails-architect skill for Rails 8.2 and Lexxy 0.7.x

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -97,7 +97,7 @@ actual purpose.
 
 - If the project isn't in a git repo, STOP and ask permission to initialize one.
 - YOU MUST STOP and ask how to handle uncommitted changes or untracked files when starting work. Suggest committing existing work first.
-- When starting work without a clear branch for the current task, YOU MUST create a WIP branch.
+- NEVER commit directly to main. ALWAYS create a feature/fix branch before making any commits.
 - YOU MUST TRACK All non-trivial changes in git.
 - YOU MUST commit frequently throughout the development process, even if your high-level tasks are not yet done. Commit your journal entries.
 - NEVER SKIP, EVADE OR DISABLE A PRE-COMMIT HOOK

--- a/claude/skills/rails-architect/SKILL.md
+++ b/claude/skills/rails-architect/SKILL.md
@@ -23,7 +23,7 @@ You are an expert Ruby on Rails architect with deep knowledge of modern Rails be
 - **Rich Domain Models**: Business logic belongs in models, controllers coordinate
 - **Simplicity**: The best code is no code; simple solutions beat clever ones
 
-## Modern Rails Stack (Rails 7+/8+)
+## Modern Rails Stack (Rails 8.2)
 
 - **Hotwire** (Turbo + Stimulus) for reactive UI without heavy JavaScript
 - **Import maps** instead of webpack/esbuild (zero-build approach)
@@ -159,7 +159,7 @@ Use FTS5 instead of external search engines. For scale: sharded search tables wi
 
 ## Reference Documentation
 
-This skill includes production-proven patterns extracted from real Rails 8.1 applications. Read the relevant docs/ file when a topic comes up.
+This skill includes production-proven patterns extracted from real Rails 8.2 applications. Read the relevant docs/ file when a topic comes up.
 
 ### Anti-Patterns and Feature Design
 - **`docs/anti-patterns.md`** - Service objects, fat controllers, god objects, custom actions, over-engineering, missing transactions, mocked tests
@@ -186,11 +186,11 @@ This skill includes production-proven patterns extracted from real Rails 8.1 app
 **When to read**: Testing strategy, test types, slow system tests, test organization.
 
 ### Lexxy Rich Text Editor
-**`docs/lexxy-rich-text-editor.md`** - Trix replacement, @mentions, slash commands, SGID attachables, editor events, syntax highlighting.
-**When to read**: Rich text editing, ActionText customization, autocomplete/mentions, embedding models.
+**`docs/lexxy-rich-text-editor.md`** - Trix replacement, pluggable editor registry, @mentions, slash commands, SGID attachables, tables, text highlighting, extensions.
+**When to read**: Rich text editing, ActionText customization, autocomplete/mentions, embedding models, pluggable editors.
 
-### Rails 8.1 Modern Stack
-**`docs/rails-8-modern-stack.md`** - Puma plugins, bin/ci, SQLite multi-database, Solid Queue/Cache/Cable, SQLite optimizations.
+### Rails 8.2 Modern Stack
+**`docs/rails-8-modern-stack.md`** - Puma plugins, bin/ci, SQLite multi-database, Solid Queue/Cache/Cable, SQLite optimizations, unified credentials, revision tracking.
 **When to read**: Rails 8 features, eliminating Redis, SQLite in production, zero-build approach.
 
 ### Production Infrastructure

--- a/claude/skills/rails-architect/docs/lexxy-rich-text-editor.md
+++ b/claude/skills/rails-architect/docs/lexxy-rich-text-editor.md
@@ -21,7 +21,7 @@ Production-proven pattern for using Lexxy instead of Trix as the rich text edito
 
 ```ruby
 # Gemfile
-gem "lexxy", "~> 0.1.26.beta"
+gem "lexxy", "~> 0.7.4.beta"
 ```
 
 ### JavaScript Import
@@ -1133,41 +1133,118 @@ export default class extends Controller {
 
 ---
 
-## Rails Main: Editor Registry (Future)
+## Pluggable Editor Registry
 
-Rails main now has a pluggable editor system. This is the future integration path for Lexxy.
+Rails 8.2 ships a pluggable editor system for ActionText. Editors register via naming convention and implement three methods.
 
-### Editor Interface
+### Editor Base Class
 
 ```ruby
+# Editors live in ActionText::Editor::<Name>Editor
 class ActionText::Editor::LexxyEditor < ActionText::Editor
-  # Convert editor HTML → canonical ActionText format
+  # Convert editor HTML → canonical ActionText storage format
   def as_canonical(editable_fragment)
-    # Lexxy already outputs canonical format, so this is a no-op
-    editable_fragment
+    editable_fragment  # Lexxy already outputs canonical format
   end
 
-  # Convert canonical format → editor HTML
+  # Convert canonical format → editor-specific HTML for editing
   def as_editable(canonical_fragment)
-    # Also a no-op since Lexxy uses the same format
-    canonical_fragment
+    canonical_fragment  # Lexxy uses the same format
+  end
+
+  # Render the editor tag in forms
+  def editor_tag(form, method, **options)
+    form.lexxy_rich_text_area(method, **options)
   end
 end
 ```
 
-### Future Configuration (Speculative)
+### Configuration
 
 ```ruby
 # config/application.rb
 config.action_text.editors = {
-  lexxy: { some_option: true }
+  lexxy: {},       # Options passed to editor initializer
+  trix: {}         # TrixEditor is the built-in reference implementation
 }
 
-# Per-model selection
+config.action_text.editor = :trix  # Default editor for rich_textarea
+```
+
+Naming convention: `:lexxy` resolves to `ActionText::Editor::LexxyEditor`.
+
+### Per-Model Editor Selection
+
+```ruby
 class Article < ApplicationRecord
   has_rich_text :content, editor: :lexxy
 end
 ```
+
+### Deprecation Note
+
+`to_trix_html` is deprecated in favor of `to_editor_html`, which delegates to the configured editor's `as_editable` method.
+
+## Tables
+
+Lexxy 0.7.x adds table support. Tables are rendered as standard HTML (`<table>`, `<tr>`, `<td>`) and stored in ActionText content. Add `table`, `tbody`, `tr`, `th`, `td` to your sanitizer's allowed tags (Lexxy's engine does this automatically).
+
+## Text Highlighting
+
+Lexxy 0.7.x supports text highlighting with 9 color slots exposed as CSS custom properties:
+
+```css
+/* Override in your stylesheet */
+--highlight-1: #fef08a;  /* yellow */
+--highlight-2: #bbf7d0;  /* green */
+/* ... through --highlight-9 */
+```
+
+## Extension System
+
+Lexxy 0.7.x introduces an experimental extension API for adding custom editor behavior:
+
+```javascript
+import { Extension } from "lexxy"
+
+class MyExtension extends Extension {
+  // Extension lifecycle and node/mark registration
+}
+
+Lexxy.configure({
+  global: {
+    extensions: [new MyExtension()]
+  }
+})
+```
+
+The extension API is experimental and may change between beta releases.
+
+## Remote Video Attachable
+
+Pattern for embedding remote videos (YouTube, Vimeo) as ActionText attachments:
+
+```ruby
+class RemoteVideo < ApplicationRecord
+  include ActionText::Attachable
+
+  validates :url, presence: true
+
+  def content_type
+    "application/vnd.actiontext.video"
+  end
+
+  def to_attachable_partial_path
+    "remote_videos/embed"
+  end
+
+  def attachable_plain_text_representation(caption = nil)
+    "[Video: #{caption || url}]"
+  end
+end
+```
+
+Use with a `/video` prompt trigger or link unfurling via `lexxy:insert-link`.
 
 ---
 

--- a/claude/skills/rails-architect/docs/passkey-authentication.md
+++ b/claude/skills/rails-architect/docs/passkey-authentication.md
@@ -1,6 +1,6 @@
 # Passkey Authentication (WebAuthn) for Rails
 
-Production-ready passkey authentication implementation pattern based on real-world Rails 8.1 application.
+Production-ready passkey authentication implementation pattern based on real-world Rails 8.2 application.
 
 ## Overview
 

--- a/claude/skills/rails-architect/docs/production-infrastructure.md
+++ b/claude/skills/rails-architect/docs/production-infrastructure.md
@@ -1,10 +1,10 @@
-# Production Infrastructure for Rails 8.1
+# Production Infrastructure for Rails 8.2
 
-Production-proven deployment patterns for Rails 8.1 applications using Kamal, SQLite with Litestream replication, and modern cloud infrastructure.
+Production-proven deployment patterns for Rails 8.2 applications using Kamal, SQLite with Litestream replication, and modern cloud infrastructure.
 
 ## Overview
 
-This guide covers the complete production infrastructure stack for deploying Rails 8.1 applications:
+This guide covers the complete production infrastructure stack for deploying Rails 8.2 applications:
 - **Kamal** - Container deployment without Kubernetes
 - **Litestream** - Continuous SQLite replication to cloud storage
 - **Cloud-init** - VM provisioning automation
@@ -911,7 +911,7 @@ Thruster automatically:
 
 ### Application Security
 
-1. **SSL everywhere**: Strict SSL mode with HSTS
+1. **SSL everywhere**: Strict SSL mode with HSTS. In Rails 8.2, `config.assume_ssl` defaults to `false`; set it to `true` when behind an SSL-terminating proxy.
 2. **Secrets management**: Environment variables, never in code
 3. **Security scanning**: Brakeman, bundler-audit, importmap audit in CI
 4. **Regular updates**: Dependabot for dependency updates
@@ -984,6 +984,14 @@ class HealthController < ApplicationController
     false
   end
 end
+```
+
+### Deployment Revision
+
+Use `Rails.app.revision` (from `REVISION` file or git SHA) for error reporting and cache keys:
+
+```ruby
+Sentry.set_context("app", { revision: Rails.app.revision })
 ```
 
 ### Logging

--- a/claude/skills/rails-architect/docs/rails-8-modern-stack.md
+++ b/claude/skills/rails-architect/docs/rails-8-modern-stack.md
@@ -1,15 +1,15 @@
-# Rails 8.1 Modern Stack
+# Rails 8.2 Modern Stack
 
-Production-proven patterns for building Rails 8.1 applications with zero-build, zero-Redis architecture, based on real-world Rails 8.1 implementation.
+Production-proven patterns for building Rails 8.2 applications with zero-build, zero-Redis architecture, based on real-world Rails 8.2 implementation.
 
 ## Overview
 
-Rails 8.1 introduces a paradigm shift toward simplicity: single-process development, database-backed infrastructure, and production-ready SQLite. This guide shows how to build modern Rails applications without webpack, Redis, or complex process management.
+Rails 8.2 introduces a paradigm shift toward simplicity: single-process development, database-backed infrastructure, and production-ready SQLite. This guide shows how to build modern Rails applications without webpack, Redis, or complex process management.
 
 ## The Modern Stack
 
 **Core Technologies:**
-- **Rails 8.1** - Latest stable release
+- **Rails 8.2** - Latest stable release
 - **SQLite** - Primary database + Queue/Cache/Cable
 - **Puma Plugins** - Integrated CSS watching and background jobs
 - **Solid Queue/Cache/Cable** - Database-backed (no Redis)
@@ -48,7 +48,7 @@ foreman start -f Procfile.dev
 - Hard to debug (which process has the error?)
 - Process lifecycle management complexity
 
-### The New Way (Rails 8.1)
+### The New Way (Rails 8.2)
 
 ```ruby
 # config/puma.rb
@@ -123,31 +123,37 @@ bin/dev  # Queue worker included automatically
 
 ### The Game Changer
 
-Rails 8.1 includes a local CI runner that runs your **exact** CI pipeline on your development machine.
+Rails 8.2 includes a local CI runner that runs your **exact** CI pipeline on your development machine.
 
 ```ruby
 # config/ci.rb
 CI.run do
   step "Setup", "bin/setup --skip-server"
-  step "Style: Ruby", "bin/rubocop"
-  step "Security: Gem audit", "bin/bundler-audit"
-  step "Security: Importmap audit", "bin/importmap audit"
-  step "Security: Brakeman", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
+
+  group "Checks", parallel: 2 do
+    step "Style: Ruby", "bin/rubocop"
+    step "Security: Gem audit", "bin/bundler-audit"
+    step "Security: Importmap audit", "bin/importmap audit"
+    step "Security: Brakeman", "bin/brakeman --quiet --no-pager --exit-on-warn --exit-on-error"
+  end
+
   step "Tests: Rails", "bin/rails test"
   step "Tests: System", "bin/rails test:system"
   step "Tests: Seeds", "env RAILS_ENV=test bin/rails db:seed:replant"
 end
 ```
 
+Steps inside a `group` with `parallel:` run concurrently, reducing CI time.
+
 ### Why This Matters
 
-**Before Rails 8.1:**
+**Before Rails 8.2:**
 - Push to GitHub → Wait for CI → Fails → Fix → Repeat
 - Feedback loop: 5-10 minutes per iteration
 - CI costs for every failed attempt
 - Can't easily test CI changes locally
 
-**With Rails 8.1:**
+**With Rails 8.2:**
 ```bash
 bin/ci  # Runs entire CI suite in ~2 minutes
 ```
@@ -214,6 +220,68 @@ bin/ci
 ✓ Tests: Seeds
 
 All checks passed!
+```
+
+## Rails 8.2 Defaults
+
+### Jobs After Transaction Commit
+
+```ruby
+# config/application.rb (default in 8.2)
+config.active_job.enqueue_after_transaction_commit = true
+```
+
+Jobs enqueued inside a transaction now wait for the transaction to commit before being dispatched. Prevents workers from picking up a job before the data it depends on is visible.
+
+### Active Storage Immediate Analysis
+
+```ruby
+# config/application.rb (default in 8.2)
+config.active_storage.analyze = :immediately
+```
+
+Blobs are analyzed (dimensions, metadata) before validation callbacks run, so `has_one_attached :avatar, content_type: "image/*"` validations work on first save.
+
+### CSRF Header-Only Verification
+
+```ruby
+# config/application.rb
+config.action_controller.csrf_token_storage_strategy = :header
+```
+
+Allows verifying CSRF tokens from the `X-CSRF-Token` header only, skipping the form `authenticity_token` param. Useful for Turbo/fetch-heavy apps where forms always submit via JavaScript.
+
+### Kamal SSL Default Change
+
+In 8.2, `config.assume_ssl` defaults to `false` (previously `true` in 8.1). If deploying behind SSL-terminating proxy (Cloudflare, Kamal with SSL), explicitly set:
+
+```ruby
+# config/environments/production.rb
+config.assume_ssl = true
+```
+
+## Unified Credentials
+
+Rails 8.2 introduces `Rails.app.creds` as the primary credentials API:
+
+```ruby
+Rails.app.creds.stripe_key         # reads from credentials
+Rails.app.creds.dig(:aws, :bucket) # nested access
+```
+
+`Rails.app` also exposes `Rails.app.name` and `Rails.app.revision`.
+
+## Deployment Revision Tracking
+
+```ruby
+Rails.app.revision  # => "abc1234" (from REVISION file or git SHA)
+```
+
+Useful for cache keys, error reporting, and deployment verification:
+
+```ruby
+config.cache_store = :solid_cache_store, { namespace: Rails.app.revision }
+Sentry.set_context("app", { revision: Rails.app.revision })
 ```
 
 ## SQLite Multi-Database Architecture
@@ -411,7 +479,7 @@ timeout: 5000  # Must be >= 5000ms to enable
 Multiple technologies to manage
 ```
 
-**New stack (Rails 8.1):**
+**New stack (Rails 8.2):**
 ```
 ┌─────────────┐
 │ Rails App   │
@@ -705,7 +773,7 @@ bin/rails db:migrate:cache
 
 ```ruby
 # Gemfile
-gem "rails", "~> 8.1.0"
+gem "rails", "~> 8.2.0"
 gem "sqlite3", ">= 2.1"
 gem "solid_queue"
 gem "solid_cache"

--- a/claude/skills/rails-architect/docs/testing-pyramid.md
+++ b/claude/skills/rails-architect/docs/testing-pyramid.md
@@ -1,6 +1,6 @@
 # Testing Pyramid for Rails Applications
 
-Production-proven testing strategy that prioritizes fast, reliable tests at appropriate levels, based on real Rails 8.1 application with 760+ tests.
+Production-proven testing strategy that prioritizes fast, reliable tests at appropriate levels, based on real Rails 8.2 application with 760+ tests.
 
 ## The Testing Pyramid
 
@@ -396,7 +396,7 @@ bin/rails test:all
 bin/rails test:all
 ```
 
-Or use Rails 8.1+ local CI:
+Or use Rails 8.2+ local CI:
 
 ```bash
 bin/ci
@@ -768,7 +768,7 @@ test "uuid validation"
 
 ## Test Coverage by Level
 
-Based on real Rails 8.1 application (760+ tests):
+Based on real Rails 8.2 application (760+ tests):
 
 | Level | Count | % | Speed | Use Case |
 |-------|-------|---|-------|----------|
@@ -812,7 +812,7 @@ bin/rails test test/controllers
 bin/rails test:system
 ```
 
-### Rails 8.1+ Local CI
+### Rails 8.2+ Local CI
 
 ```bash
 # Run full CI suite locally
@@ -821,13 +821,10 @@ bin/ci
 
 This runs:
 1. Setup and dependency check
-2. RuboCop style checking
-3. Bundler audit (gem vulnerability scanning)
-4. Importmap audit (JavaScript dependency scanning)
-5. Brakeman security analysis
-6. Unit and integration tests
-7. System tests
-8. Database seed verification
+2. Checks group (parallel): RuboCop, bundler audit, importmap audit, Brakeman
+3. Unit and integration tests
+4. System tests
+5. Database seed verification
 
 ## Common Anti-Patterns
 

--- a/claude/skills/rails-architect/docs/uuidv7-sqlite.md
+++ b/claude/skills/rails-architect/docs/uuidv7-sqlite.md
@@ -1,6 +1,6 @@
 # UUIDv7 Primary Keys with SQLite
 
-Complete guide to implementing UUIDv7 as primary keys in Rails applications using SQLite, based on production Rails 8.1 implementation.
+Complete guide to implementing UUIDv7 as primary keys in Rails applications using SQLite, based on production Rails 8.2 implementation.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Update all version references from Rails 8.1 → 8.2 across 7 skill docs
- Add Rails 8.2 features: jobs-after-transaction-commit, immediate Active Storage analysis, CSRF header-only strategy, `assume_ssl` default change, unified credentials (`Rails.app.creds`), revision tracking (`Rails.app.revision`), CI parallel groups
- Replace speculative editor registry section with real Rails 8.2 `ActionText::Editor` API (base class, naming convention, per-model selection, `to_trix_html` deprecation)
- Update Lexxy gem from 0.1.26.beta → 0.7.4.beta, add tables, text highlighting, extension system, remote video attachable

## Test plan

- [ ] Read through each modified doc for accuracy and consistency
- [ ] Grep for stale "8.1" references (only intentional one should be the `assume_ssl` comparison)
- [ ] Grep for stale "0.1.26" references (should be zero)
- [ ] Verify SKILL.md stays under 500 lines