### PR TITLE
Fix inaccuracies in rails-architect skill docs

### DIFF
--- a/claude/skills/rails-architect/docs/lexxy-rich-text-editor.md
+++ b/claude/skills/rails-architect/docs/lexxy-rich-text-editor.md
@@ -1135,12 +1135,13 @@ export default class extends Controller {
 
 ## Pluggable Editor Registry
 
-Rails 8.2 ships a pluggable editor system for ActionText. Editors register via naming convention and implement three methods.
+Rails 8.2 extracts `ActionText::Editor` as a base class, decoupling ActionText from Trix. `ActionText::TrixEditor` is the built-in reference implementation.
 
-### Editor Base Class
+### Editor Interface
+
+Custom editors subclass `ActionText::Editor` and implement two transformation methods:
 
 ```ruby
-# Editors live in ActionText::Editor::<Name>Editor
 class ActionText::Editor::LexxyEditor < ActionText::Editor
   # Convert editor HTML → canonical ActionText storage format
   def as_canonical(editable_fragment)
@@ -1151,27 +1152,8 @@ class ActionText::Editor::LexxyEditor < ActionText::Editor
   def as_editable(canonical_fragment)
     canonical_fragment  # Lexxy uses the same format
   end
-
-  # Render the editor tag in forms
-  def editor_tag(form, method, **options)
-    form.lexxy_rich_text_area(method, **options)
-  end
 end
 ```
-
-### Configuration
-
-```ruby
-# config/application.rb
-config.action_text.editors = {
-  lexxy: {},       # Options passed to editor initializer
-  trix: {}         # TrixEditor is the built-in reference implementation
-}
-
-config.action_text.editor = :trix  # Default editor for rich_textarea
-```
-
-Naming convention: `:lexxy` resolves to `ActionText::Editor::LexxyEditor`.
 
 ### Per-Model Editor Selection
 
@@ -1191,14 +1173,7 @@ Lexxy 0.7.x adds table support. Tables are rendered as standard HTML (`<table>`,
 
 ## Text Highlighting
 
-Lexxy 0.7.x supports text highlighting with 9 color slots exposed as CSS custom properties:
-
-```css
-/* Override in your stylesheet */
---highlight-1: #fef08a;  /* yellow */
---highlight-2: #bbf7d0;  /* green */
-/* ... through --highlight-9 */
-```
+Lexxy 0.7.x supports text highlighting with configurable color slots. Colors are customizable via CSS custom properties in your stylesheet. See the [Lexxy documentation](https://basecamp.github.io/lexxy) for the current property names.
 
 ## Extension System
 

--- a/claude/skills/rails-architect/docs/production-infrastructure.md
+++ b/claude/skills/rails-architect/docs/production-infrastructure.md
@@ -911,7 +911,7 @@ Thruster automatically:
 
 ### Application Security
 
-1. **SSL everywhere**: Strict SSL mode with HSTS. In Rails 8.2, `config.assume_ssl` defaults to `false`; set it to `true` when behind an SSL-terminating proxy.
+1. **SSL everywhere**: Strict SSL mode with HSTS. New Rails 8.2 apps no longer generate `assume_ssl`/`force_ssl` in `production.rb`; set both to `true` when behind an SSL-terminating proxy.
 2. **Secrets management**: Environment variables, never in code
 3. **Security scanning**: Brakeman, bundler-audit, importmap audit in CI
 4. **Regular updates**: Dependabot for dependency updates

--- a/claude/skills/rails-architect/docs/rails-8-modern-stack.md
+++ b/claude/skills/rails-architect/docs/rails-8-modern-stack.md
@@ -242,22 +242,25 @@ config.active_storage.analyze = :immediately
 
 Blobs are analyzed (dimensions, metadata) before validation callbacks run, so `has_one_attached :avatar, content_type: "image/*"` validations work on first save.
 
-### CSRF Header-Only Verification
+### CSRF Protection via Sec-Fetch-Site
+
+Rails 8.2 introduces a new CSRF protection strategy based on the `Sec-Fetch-Site` browser header:
 
 ```ruby
-# config/application.rb
-config.action_controller.csrf_token_storage_strategy = :header
+# config/application.rb (default for new 8.2 apps)
+config.action_controller.csrf_protection_strategy = :header_only
 ```
 
-Allows verifying CSRF tokens from the `X-CSRF-Token` header only, skipping the form `authenticity_token` param. Useful for Turbo/fetch-heavy apps where forms always submit via JavaScript.
+`:header_only` relies on the browser's `Sec-Fetch-Site` header, eliminating the need for `authenticity_token` form params. Use `:header_or_legacy_token` for a gradual migration that falls back to traditional token verification.
 
-### Kamal SSL Default Change
+### SSL Configuration
 
-In 8.2, `config.assume_ssl` defaults to `false` (previously `true` in 8.1). If deploying behind SSL-terminating proxy (Cloudflare, Kamal with SSL), explicitly set:
+New Rails 8.2 apps no longer generate `config.assume_ssl` or `config.force_ssl` in `production.rb`, so Kamal deployments work out of the box without SSL. When deploying behind an SSL-terminating proxy, explicitly enable:
 
 ```ruby
 # config/environments/production.rb
 config.assume_ssl = true
+config.force_ssl = true
 ```
 
 ## Combined Credentials
@@ -275,7 +278,7 @@ Rails.app.creds.require(:aws, :bucket)                      # nested: checks AWS
 ## Deployment Revision Tracking
 
 ```ruby
-Rails.app.revision  # => "abc1234" (from REVISION file or git SHA)
+Rails.app.revision  # => "abc1234" (checks ENV["REVISION"], then REVISION file, then git SHA)
 ```
 
 Useful for cache keys, error reporting, and deployment verification:


### PR DESCRIPTION
## Summary

- Fix CSRF section: replace fabricated config name with real `Sec-Fetch-Site` protection strategy (`header_only` / `header_or_legacy_token`)
- Fix SSL section: `assume_ssl` was never `true` by default; the real change is new 8.2 apps don't generate it in `production.rb`
- Fix revision lookup: add `ENV["REVISION"]` as first priority in chain
- Fix editor registry: remove unverified `editor_tag` method and uncertain config hash, keep confirmed `as_canonical`/`as_editable` interface
- Fix Lexxy highlighting: remove fabricated CSS variable names, link to docs

## Test plan

- [ ] Read corrected sections against source PRs: [#56350](https://github.com/rails/rails/pull/56350), [#56010](https://github.com/rails/rails/pull/56010), [#56742](https://github.com/rails/rails/pull/56742), [#51238](https://github.com/rails/rails/pull/51238)