### PR TITLE
switch from rbenv to mise

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -70,6 +70,8 @@ brew "libyaml"
 brew "lynx"
 # Mac App Store command-line interface
 brew "mas"
+# Polyglot runtime manager (asdf rust clone)
+brew "mise"
 # HTTP/2 C Library
 brew "nghttp2"
 # Small build system for use with gyp or CMake
@@ -88,10 +90,6 @@ brew "python@3.9"
 brew "qrencode"
 # Cross-platform application and UI framework
 brew "qt"
-# Install various Ruby versions and implementations
-brew "ruby-build"
-# Ruby version manager
-brew "rbenv"
 # Rsync for cloud storage
 brew "rclone"
 # Persistent key-value database, with built-in net interface

--- a/zshrc
+++ b/zshrc
@@ -28,13 +28,6 @@ if [[ $una == *"arm64"* ]]; then
   eval "$(/opt/homebrew/bin/brew shellenv)"
 fi
 
-# setup rbenv.
-# When entering tmux, this will add a duplicate entry into PATH. However, it's
-# needed because otherwise rbenv will come after the system ruby path.
-if command -v rbenv &>/dev/null; then
-  eval "$(rbenv init - zsh)"
-fi
-
 # setup mise for runtime version management
 if command -v mise &>/dev/null; then
   eval "$(mise activate zsh)"


### PR DESCRIPTION
## Summary
- Replace `rbenv` + `ruby-build` with `mise` for runtime version management
- Drop the rbenv activation block from `zshrc` (the existing mise block already handled activation)
- Brewfile: remove `rbenv`, `ruby-build`; add `mise`

Local migration already executed: Ruby 4.0.4 reinstalled under `~/.local/share/mise/installs/ruby/4.0.4`, `~/.rbenv` removed (~1.2GB reclaimed), global config at `~/.config/mise/config.toml`. Per-project gems repopulated via `bundle install` as needed.

## Test plan
- [ ] `exec zsh` in a new terminal — no errors from the activation block
- [ ] `which ruby` resolves to the mise install path
- [ ] `ruby -v` reports 4.0.4
- [ ] `which rbenv` returns "not found"
- [ ] In a Rails project: `bundle install && bin/rails -v` works
- [ ] `brew bundle check --file=~/.dotfiles/Brewfile` passes on this machine