### PR TITLE
clean up vimrc audit findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This is Brian's personal dotfiles repository containing shell configurations (zs
 - **claude/**: Claude Code configuration directory. Symlink this to `~/.claude` for global Claude settings. Contains CLAUDE.md (project-specific guidelines), settings.json, two custom skills (design-with-tailwind-plus and rails-architect), and plugin marketplace integration.
 - **Brewfile**: Homebrew package manifest with 157 packages/taps for automated environment setup.
 - **install.sh**: Automated dotfiles installation script with backup functionality for existing files.
-- **Other configs**: psqlrc, sqliterc, gemrc, gitignore_global, hushlogin for database and shell customization.
+- **Other configs**: psqlrc, sqliterc, gemrc, gitignore_global, ignore (cross-project rg/ag ignore patterns, symlinked to `~/.ignore`), hushlogin for database and shell customization.
 
 ### Key Patterns
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Or manually create individual symbolic links:
 # Core configuration files
 ln -s ~/.dotfiles/gemrc ~/.gemrc
 ln -s ~/.dotfiles/gitignore_global ~/.gitignore_global
+ln -s ~/.dotfiles/ignore ~/.ignore
 ln -s ~/.dotfiles/hushlogin ~/.hushlogin
 ln -s ~/.dotfiles/psqlrc ~/.psqlrc
 ln -s ~/.dotfiles/sqliterc ~/.sqliterc

--- a/ignore
+++ b/ignore
@@ -1,0 +1,51 @@
+# Cross-project ignore patterns for ripgrep and the_silver_searcher.
+# Symlinked to ~/.ignore — read globally by rg and ag in addition to
+# per-project .gitignore files. Use gitignore-style syntax.
+
+# version control
+.git/
+.svn/
+.hg/
+
+# OS / editor cruft
+.DS_Store
+*.swp
+*.swo
+*.swn
+
+# vim local dirs
+.vim/backup/
+.vim/swap/
+.vim/undo/
+
+# language ecosystems
+node_modules/
+bower_components/
+vendor/
+Godeps/_workspace/
+*.pyc
+__pycache__/
+.gem/
+.npm/
+.node-gyp/
+
+# build / generated
+dist/
+_site/
+tmp/
+.cache/
+.caches/
+*.o
+*.out
+
+# infrastructure
+.vagrant/
+.terraform/
+
+# apple ecosystem
+*.xcodeproj/
+Assets.xcassets/
+
+# misc
+.keep
+.particledev/

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ echo
 # Core configuration files
 link_file "$DOTFILES_DIR/gemrc" "$HOME/.gemrc"
 link_file "$DOTFILES_DIR/gitignore_global" "$HOME/.gitignore_global"
+link_file "$DOTFILES_DIR/ignore" "$HOME/.ignore"
 link_file "$DOTFILES_DIR/hushlogin" "$HOME/.hushlogin"
 link_file "$DOTFILES_DIR/psqlrc" "$HOME/.psqlrc"
 link_file "$DOTFILES_DIR/sqliterc" "$HOME/.sqliterc"

--- a/vimrc
+++ b/vimrc
@@ -20,7 +20,6 @@ Plug 'alvan/vim-closetag' " closes matching HTML tags
 
 " Ruby plugin
 Plug 'vim-ruby/vim-ruby'
-Plug 'prabirshrestha/vim-lsp'
 
 " Terraform
 Plug 'hashivim/vim-terraform'
@@ -28,7 +27,6 @@ Plug 'hashivim/vim-terraform'
 " All of your Plugins must be added before the following line
 call plug#end()            " required
 
-set nocompatible
 set encoding=utf-8
 set showcmd
 set ruler
@@ -37,23 +35,26 @@ set tabstop=2
 set shiftwidth=2
 set softtabstop=2
 set expandtab
-set backspace=2
+set backspace=indent,eol,start
 set autoindent
 set cursorline
 set hlsearch                    " highlight matches
 set incsearch                   " incremental searching
-set ignorecase                  " searches are case insensitive...
+set ignorecase                  " case-insensitive...
+set smartcase                   " ...unless the pattern has uppercase
 set laststatus=2                " something about vim-airline
 set noshowmode
 set noerrorbells visualbell t_vb= "turn off annoying bells
-set ttyfast                     " when key repeat rate is really fast, keep up!
 set hidden                      " Hide a buffer when it is abandoned.
+set scrolloff=5                 " keep 5 lines of context above/below cursor
+set mouse=a                     " mouse support in all modes
 " Open new split panes to right and bottom, which feels more natural
 set splitbelow
 set splitright
 set backupdir=~/.vim/backup//
 set directory=~/.vim/swap//
 set undodir=~/.vim/undo//
+set undofile                    " persist undo history across sessions
 syntax on
 set nocursorcolumn
 set nocursorline
@@ -83,7 +84,7 @@ nnoremap <leader>dd :Lexplore %:p:h<CR>
 " open Netrw in the current working directory
 nnoremap <Leader>da :Lexplore<CR>
 
-" Explore window 30%
+" Explore window 20%
 let g:netrw_winsize = 20
 
 " Enable spell checking for certain filetypes
@@ -91,40 +92,15 @@ let g:netrw_winsize = 20
 " Turn on syntax highlighting for git commits
 " autocmd FileType gitcommit syntax on
 
-" Set ignore list
-set wildignore+=Godeps/_workspace/**,**/_site/**,**/bower_components/**,**/node_modules/**,**/vendor/**,**/tmp/**,*.o,*.out,*.log,**/cookbooks/**,*.swp,*.swo
+" Skip these in vim's built-in file completion (:edit, :find, glob()).
+" rg has its own ignore mechanism via ~/.ignore + .gitignore.
+set wildignore+=*.swp,*.swo,*~
+set wildignore+=.git/**,**/.DS_Store
+set wildignore+=**/node_modules/**,**/vendor/**,**/tmp/**
 
-" This overrides wildignore when using ctrlp
-let g:ctrlp_user_command = 'ag %s --ignore-case --skip-vcs-ignores --nocolor --nogroup --hidden
-      \ --ignore ".git/"
-      \ --ignore ".svn/"
-      \ --ignore ".hg/"
-      \ --ignore ".vagrant/"
-      \ --ignore ".cache/"
-      \ --ignore ".caches/"
-      \ --ignore ".gem/"
-      \ --ignore ".config/"
-      \ --ignore ".node-gyp/"
-      \ --ignore ".npm/"
-      \ --ignore ".particledev/"
-      \ --ignore "Godeps/_workspace/"
-      \ --ignore "_site/"
-      \ --ignore "bower_components/"
-      \ --ignore "node_modules/"
-      \ --ignore ".DS_Store"
-      \ --ignore "*.o"
-      \ --ignore "*.out"
-      \ --ignore "*.swp"
-      \ --ignore "*.swo"
-      \ --ignore "*.pyc"
-      \ --ignore ".keep"
-      \ --ignore "vendor/"
-      \ --ignore "tmp/"
-      \ --ignore "dist/"
-      \ --ignore ".terraform"
-      \ --ignore "*.xcodeproj/"
-      \ --ignore "Assets.xcassets/"
-      \ -g ""'
+" ctrlp uses ripgrep. Project ignores live in .gitignore; cross-project
+" ignores live in ~/.ignore (tracked as `ignore` in this repo).
+let g:ctrlp_user_command = 'rg %s --files --hidden --glob "!.git/*"'
 
 let g:ctrlp_map = '<leader>p'
 let g:ctrlp_cmd = 'CtrlP'
@@ -136,19 +112,15 @@ let g:ctrlp_cmd = 'CtrlP'
 nnoremap <silent> <C-l> :nohl<CR><C-l>
 " Repeat last command
 vnoremap . :norm.<CR>
-" Open ECMAScript 6 files as javascript filetypes
-au BufNewFile,BufRead *.es6 set filetype=javascript
 
 " Open a new empty buffer
-nmap <leader>T :enew<CR>
-nmap <leader>bq :bp <BAR> bd #<CR>
-nmap <leader>l :bnext<CR>
-nmap <leader>h :bprevious<CR>
+nnoremap <leader>T :enew<CR>
+nnoremap <leader>bq :bp <BAR> bd #<CR>
+nnoremap <leader>l :bnext<CR>
+nnoremap <leader>h :bprevious<CR>
 
-" any .md files are markdown files
-autocmd BufNewFile,BufReadPost *.md set filetype=markdown
 " Wrap text at 80 chars for markdown files
-au BufRead,BufNewFile *.md setlocal textwidth=80
+autocmd FileType markdown setlocal textwidth=80
 
 " Autocommand to run git stripspace on file save
 augroup GitStripspace
@@ -224,14 +196,11 @@ let g:airline_symbols.whitespace = 'Ξ'
 " Setup closetag.vim to only work with html files
 let g:closetag_filenames = '*.html,*.html.erb'
 
-" use go formatting
-autocmd FileType go setlocal tabstop=4 softtabstop=4 shiftwidth=4 noexpandtab
+" ─── vim-go ──────────────────────────────────────────────────────────────────
 
-" Setup vim-go to automatically import paths
 let g:go_fmt_command = "goimports"
-" use gopls
 let g:go_def_mode='gopls'
 let g:go_info_mode='gopls'
-au FileType go nmap <leader>d :GoDef<CR>
-au FileType go nmap <leader>ga :GoAlternate<CR>
-au FileType go nmap <leader>gd :GoDecls<CR>
+au FileType go nnoremap <leader>gd :GoDef<CR>
+au FileType go nnoremap <leader>gD :GoDecls<CR>
+au FileType go nnoremap <leader>ga :GoAlternate<CR>


### PR DESCRIPTION
## Summary

Cleanup pass on `vimrc`. Settings hygiene, mappings made non-recursive, ctrlp migrated from `ag` to `rg`, autocmds pruned. Adds a top-level `ignore` file for cross-project rg/ag patterns.

Two items from the audit are deferred:
- **vim-lsp / ruby-lsp setup** — we wired it up, decided the gutter noise wasn't worth it right now, ripped it back out. Will revisit.
- **airline theme to match the new tmux palette** — held until later.

## Changes

### vimrc settings

| Before | After |
|---|---|
| `set nocompatible` | (deleted — set automatically when vimrc is present) |
| `set ttyfast` | (deleted — always-on in vim 9) |
| `set backspace=2` | `set backspace=indent,eol,start` |
| `set ignorecase` only | + `set smartcase` |
| `set undodir=...` only | + `set undofile` (now actually persists undo across sessions) |
| (default scrolloff=0) | `set scrolloff=5` |
| (no mouse) | `set mouse=a` (consistent with tmux mouse on) |

### Mappings

- `nmap` → `nnoremap` for `<leader>T/bq/l/h` and Go bindings. The current RHS strings happen to be safe (all start with `:`), but defaulting to non-recursive is the standard guard against future remap surprises.
- Rebind `<leader>d` (GoDef) → `<leader>gd` and `<leader>gd` (GoDecls) → `<leader>gD`. Removes the 1-second `timeoutlen` wait you used to get in Go files from the `<leader>d` / `<leader>dd` (netrw) collision.

### Autocmds

- Drop `BufNewFile,BufRead *.es6 set filetype=javascript` — dead, no `.es6` files in 2026.
- Drop `BufNewFile,BufReadPost *.md set filetype=markdown` — Vim's bundled filetype.vim already detects `.md` as markdown.
- Change markdown textwidth from `BufRead,BufNewFile *.md` to `FileType markdown` so it also catches `.markdown`, `.mdown`, `.mkd`, etc.
- Drop `autocmd FileType go setlocal tabstop=4 ...` — vim-go's bundled `ftplugin/go.vim` already does this.

### ctrlp + new \`ignore\` file

- `g:ctrlp_user_command` replaced: 30 lines of `ag` flags → `rg %s --files --hidden --glob \"!.git/*\"` (one line).
- New top-level `ignore` file in this repo, symlinked to `~/.ignore` by install.sh. Both rg and ag honor it for any search inside `~/`.
- `wildignore` pruned from 12 patterns to 8 high-value ones. Dropped `Godeps/_workspace/`, `bower_components/`, `cookbooks/`, `_site/` (all dead in 2026) and `*.o`/`*.out`/`*.log` (rarely tab-completed near). Added `.git/**` and `**/.DS_Store` (worth excluding from completion).

### Docs / install

- `install.sh` symlinks `ignore` → `~/.ignore`.
- `README.md` manual symlink list includes `ignore`.
- `CLAUDE.md` \"Other configs\" line mentions `ignore`.

## Test plan

- [x] `vim -u ~/.dotfiles/vimrc -i NONE` loads with 0 errors
- [x] `set smartcase? undofile? mouse? scrolloff? backspace?` all show the new values after sourcing vimrc
- [x] `~/.ignore` symlinked; tested rg in `~/rgtest` correctly excludes `*.swp`
- [x] `vim` opens, `:CtrlP` runs rg without errors
- [x] No remaining LSP / asyncomplete references after revert (verified `grep -rn lsp\|asyncomplete vimrc` returns empty)