### PR TITLE
enable tmux automatic-rename for windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,6 @@ This is Brian's personal dotfiles repository containing shell configurations (zs
 
 **Vim Stripspace**: The vimrc includes a sophisticated autocmd that runs `git stripspace` on save, with exclusions for certain file types. It preserves cursor position and undo history using temporary undo files. Don't modify this pattern without testing thoroughly.
 
-**Tmux Window Naming**: Tmux is configured to accept window name changes via escape sequences. Use `printf '\033k%s\033\\' "name"` to set window names programmatically. This is used by the global CLAUDE.md tmux window management rules.
-
 **API Token Pattern**: Both GitHub and Anthropic API tokens are sourced from separate files (`~/.github-api-token`, `~/.anthropic-api-token`) in the home directory, not stored in this repo. These files should export the appropriate environment variables.
 
 ### Custom Claude Skills

--- a/tmux.conf
+++ b/tmux.conf
@@ -18,9 +18,11 @@ set -g renumber-windows on
 # Mouse: click to focus, drag dividers, wheel-scroll history
 set -g mouse on
 
-# allow escape sequences to rename tmux windows
+# Auto-rename the window from the active pane's current command. Manually
+# renamed windows (via `prefix ,` or escape sequence) stay locked to that
+# name and won't be auto-renamed for the rest of the session.
 set-window-option -g allow-rename on
-set-window-option -g automatic-rename off
+set-window-option -g automatic-rename on
 
 set-option -g default-shell /bin/zsh
 # Non-login shells in panes — avoids /etc/zprofile re-running per pane


### PR DESCRIPTION
## Summary

Flip `automatic-rename` from off to on. Window names in the status bar now follow the active pane's current command (`vim`, `zsh`, `psql`, `node`, etc.) and update as you switch panes within a window.

Windows that have been **explicitly** named (via `prefix ,` or via a program emitting the `\033k...\033\\` title escape) still stick to that name — tmux maintains a per-window override that beats the global default.

## Changes

**tmux.conf** — `set-window-option -g automatic-rename off` → `on`, plus a comment explaining the manual-rename interaction.

**CLAUDE.md** — remove the stale "Tmux Window Naming" paragraph. It described a `printf '\033k%s\033\\' "name"` workflow and claimed it was used by "the global CLAUDE.md tmux window management rules" — those rules don't exist (grepped `~/.claude/CLAUDE.md` — no match). The escape-sequence rename workflow is no longer used.

## Note for existing sessions

If your already-running tmux session has windows that were previously manually named (or had escape-sequence renames from old programs), they'll stay locked to those old names because of the per-window `automatic-rename off` override. To unlock all of them in a live session:

```bash
for w in $(tmux list-windows -F '#I'); do
  tmux set-window-option -u -t :$w automatic-rename
done
```

New windows will pick up the new behavior automatically.

## Test plan

- [x] `automatic-rename` global option flipped (verified `tmux show-window-options -gv automatic-rename` → `on`)
- [x] Unset per-window override on existing windows; verified they immediately picked up the active pane's command (`zsh`, `node`, etc.)
- [x] Verified switching panes within a window updates the displayed name