### PR TITLE
Keep tmux copy-mode open on mouse drag-select

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -58,6 +58,12 @@ if-shell "command -v pbcopy" \
   "bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'pbcopy'" \
   "bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel"
 
+# Mouse drag-select: copy to clipboard and stay in copy-mode (default is
+# copy-pipe-and-cancel, which exits the moment you release the mouse button)
+if-shell "command -v pbcopy" \
+  "bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-no-clear 'pbcopy'" \
+  "bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection-no-clear"
+
 # F12 toggles outer tmux off for nested sessions
 bind -T root F12 \
   set prefix None \;\


### PR DESCRIPTION
## Summary
- Override the default `MouseDragEnd1Pane` binding in `copy-mode-vi` so drag-selecting with the mouse pipes the selection to `pbcopy` and stays in copy-mode.
- Default tmux behavior is `copy-pipe-and-cancel`, which exits the moment the button is released and never reaches the system clipboard.

## Test plan
- [x] Reload config: `tmux source-file ~/.tmux.conf`
- [x] Enter copy-mode (scroll wheel or `prefix [`), drag-select text — selection lands in pbcopy and copy-mode stays open
- [x] `y` still works as before